### PR TITLE
Update action validation error message format

### DIFF
--- a/src/api/actions/controllers/actions-validation.controller.js
+++ b/src/api/actions/controllers/actions-validation.controller.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { statusCodes } from '~/src/api/common/constants/status-codes.js'
 import { validateLandActions } from '~/src/api/actions/service/land-actions.service.js'
 import {
@@ -36,6 +37,7 @@ const LandActionsValidateController = {
     try {
       const { landActions } = request.payload
       request.logger.info(`Controller validating land actions ${landActions}`)
+
       const validationResponse = await validateLandActions(
         landActions,
         request.logger
@@ -45,12 +47,12 @@ const LandActionsValidateController = {
         .response({ message: 'success', ...validationResponse })
         .code(statusCodes.ok)
     } catch (error) {
-      request.logger.error(`Error validating land actions: ${error.message}`)
-      return h
-        .response({
-          message: error.message
-        })
-        .code(statusCodes.notFound)
+      const errorMessage = `Error validating land actions: ${error.message}`
+      request.logger.error(errorMessage, {
+        error: error.message,
+        stack: error.stack
+      })
+      return Boom.internal(errorMessage)
     }
   }
 }

--- a/src/api/actions/schema/action-validation.schema.js
+++ b/src/api/actions/schema/action-validation.schema.js
@@ -22,7 +22,12 @@ const landActionSchema = Joi.object({
 
 const landActionValidationResponseSchema = Joi.object({
   message: Joi.string().required(),
-  errorMessages: Joi.array().items(Joi.string()).required(),
+  errorMessages: Joi.array().items(
+    Joi.object({
+      code: Joi.string().required(),
+      description: Joi.string().required()
+    })
+  ),
   valid: Joi.boolean().required()
 })
 

--- a/src/api/actions/service/land-actions.service.js
+++ b/src/api/actions/service/land-actions.service.js
@@ -1,5 +1,3 @@
-import Boom from '@hapi/boom'
-
 /**
  * validates land actions data and return isValidationSucess flag
  * @returns {object} isValidationSucess boolean flag
@@ -7,27 +5,18 @@ import Boom from '@hapi/boom'
  * @param {object} logger - Logger instance
  */
 function validateLandActions(landActions, logger) {
-  const firstLandAction =
-    Array.isArray(landActions) && landActions.length > 0
-      ? landActions[0]
-      : landActions
-  if (
-    !firstLandAction ||
-    !Array.isArray(landActions) ||
-    landActions.length === 0
-  ) {
-    logger.error(
-      `Error validating land actions, no land and actions data provided`
-    )
-    throw Boom.badRequest('landActions are required')
-  }
-
+  logger.info(
+    `Validating land actions, landActions: ${JSON.stringify(landActions)}`
+  )
   const errorMessages =
     landActions.length > 0 &&
     landActions[0].actions.length > 0 &&
     landActions[0].actions.reduce((errors, item) => {
       if (item.quantity > 100) {
-        errors.push(`${item.code} is exceeding max limit 100`)
+        errors.push({
+          code: item.code,
+          description: `${item.code} is exceeding max limit 100`
+        })
       }
       return errors
     }, [])
@@ -38,25 +27,4 @@ function validateLandActions(landActions, logger) {
   }
 }
 
-/**
- * calculate payment amount for given land actions data
- * @returns {object} The land actions payment amount
- * @param {object} landActions - The parcel to fetch
- * @param {object} logger - Logger instance
- */
-function calculatePayment(landActions, logger) {
-  if (!landActions) {
-    logger.error(
-      `Error calculating payment land actions, no land and actions data provided`
-    )
-    throw Boom.badRequest('landActions are required')
-  }
-
-  return {
-    payment: {
-      total: 100.98
-    }
-  }
-}
-
-export { validateLandActions, calculatePayment }
+export { validateLandActions }

--- a/src/api/actions/service/land-actions.service.test.js
+++ b/src/api/actions/service/land-actions.service.test.js
@@ -1,8 +1,5 @@
-import Boom from '@hapi/boom'
-import {
-  validateLandActions,
-  calculatePayment
-} from '~/src/api/actions/service/land-actions.service.js'
+import { validateLandActions } from '~/src/api/actions/service/land-actions.service.js'
+import { mockLandActions } from '~/src/api/actions/fixtures/index.js'
 
 describe('validateLandActions', () => {
   const mockLogger = {
@@ -15,82 +12,17 @@ describe('validateLandActions', () => {
     jest.clearAllMocks()
   })
 
-  const landActions = [
-    {
-      sheetId: 'SX0679',
-      parcelId: '9238',
-      sbi: '123456789',
-      actions: [
-        {
-          code: 'BND1',
-          quantity: 99
-        },
+  it('should return validation for given valid land actions', () => {
+    const expectedValidationResp = {
+      errorMessages: [
         {
           code: 'BND2',
-          quantity: 200
+          description: 'BND2 is exceeding max limit 100'
         }
-      ]
-    }
-  ]
-
-  it('validateLandActions should throw a bad request error if no land actions is provided', () => {
-    expect(() => validateLandActions(null, mockLogger)).toThrow(Boom.Boom)
-
-    let error
-    try {
-      validateLandActions(null, mockLogger)
-    } catch (err) {
-      error = err
-    }
-    expect(error.isBoom).toBe(true)
-    expect(error.output.payload.message).toBe('landActions are required')
-  })
-
-  it('validateLandActions should throw a bad request error if land actions list not is provided', () => {
-    expect(() => validateLandActions(landActions[0], mockLogger)).toThrow(
-      Boom.Boom
-    )
-
-    let error
-    try {
-      validateLandActions(null, mockLogger)
-    } catch (err) {
-      error = err
-    }
-    expect(error.isBoom).toBe(true)
-    expect(error.output.payload.message).toBe('landActions are required')
-  })
-
-  it('calculatePayment should throw a bad request error if no land actions is provided', () => {
-    expect(() => calculatePayment(null, mockLogger)).toThrow(Boom.Boom)
-    let error
-    try {
-      calculatePayment(null, mockLogger)
-    } catch (err) {
-      error = err
-    }
-    expect(error.isBoom).toBe(true)
-    expect(error.output.payload.message).toBe('landActions are required')
-  })
-
-  it('should return calculated payments for given valid land actions', async () => {
-    const expectedPayment = {
-      payment: {
-        total: 100.98
-      }
-    }
-
-    const result = await calculatePayment(landActions, mockLogger)
-
-    expect(result).toEqual(expectedPayment)
-  })
-
-  it('should return validation for given valid land actions', async () => {
-    const expectedValidationResp = {
-      errorMessages: ['BND2 is exceeding max limit 100'],
+      ],
       valid: false
     }
-    const result = await validateLandActions(landActions, mockLogger)
+    const result = validateLandActions(mockLandActions.landActions, mockLogger)
 
     expect(result).toEqual(expectedValidationResp)
   })

--- a/src/api/payment/schema/payment-calculate.schema.test.js
+++ b/src/api/payment/schema/payment-calculate.schema.test.js
@@ -1,0 +1,75 @@
+import { PaymentCalculateResponseSchema } from './payment-calculate.schema.js'
+
+describe('Payment Calculate Schema Validation', () => {
+  describe('PaymentCalculateResponseSchema', () => {
+    it('should validate correct payment calculate response', () => {
+      const validResponse = {
+        message: 'Payment calculated successfully',
+        payment: {
+          total: 1250.5
+        }
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(validResponse)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should validate response with zero payment total', () => {
+      const validResponse = {
+        message: 'Payment calculated successfully',
+        payment: {
+          total: 0
+        }
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(validResponse)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should reject missing message', () => {
+      const invalidResponse = {
+        payment: {
+          total: 1250.5
+        }
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(invalidResponse)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain('"message" is required')
+    })
+
+    it('should reject missing payment object', () => {
+      const invalidResponse = {
+        message: 'Payment calculated successfully'
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(invalidResponse)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain('"payment" is required')
+    })
+
+    it('should reject missing payment total', () => {
+      const invalidResponse = {
+        message: 'Payment calculated successfully',
+        payment: {}
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(invalidResponse)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain('"payment.total" is required')
+    })
+
+    it('should reject non-number payment total', () => {
+      const invalidResponse = {
+        message: 'Payment calculated successfully',
+        payment: {
+          total: 'not-a-number'
+        }
+      }
+
+      const result = PaymentCalculateResponseSchema.validate(invalidResponse)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain('"payment.total" must be a number')
+    })
+  })
+})

--- a/src/api/payment/service/payment.service.js
+++ b/src/api/payment/service/payment.service.js
@@ -1,17 +1,18 @@
-import Boom from '@hapi/boom'
-
 /**
  * calculate payment amount for given land actions data
  * @returns {object} The land actions payment amount
- * @param {object} landActions - The parcel to fetch
+ * @param {object} landActions - The land actions
  * @param {object} logger - Logger instance
  */
 function calculatePayment(landActions, logger) {
-  if (!landActions) {
-    logger.error(
-      `Error calculating payment land actions, no land and actions data provided`
-    )
-    throw Boom.badRequest('landActions are required')
+  // mock error condition, replace with actual error condition
+  if (
+    !landActions ||
+    landActions?.length === 0 ||
+    landActions[0]?.sheetId === ''
+  ) {
+    logger.error('Unable to calculate payment')
+    return null
   }
 
   return {

--- a/src/api/payment/service/payment.service.test.js
+++ b/src/api/payment/service/payment.service.test.js
@@ -1,5 +1,5 @@
-import Boom from '@hapi/boom'
 import { calculatePayment } from '~/src/api/payment/service/payment.service.js'
+import { mockLandActions } from '~/src/api/actions/fixtures/index.js'
 
 describe('calculatePayment', () => {
   const mockLogger = {
@@ -12,44 +12,20 @@ describe('calculatePayment', () => {
     jest.clearAllMocks()
   })
 
-  const landActions = [
-    {
-      sheetId: 'SX0679',
-      parcelId: '9238',
-      sbi: '123456789',
-      actions: [
-        {
-          code: 'BND1',
-          quantity: 99
-        },
-        {
-          code: 'BND2',
-          quantity: 200
-        }
-      ]
-    }
-  ]
+  it('calculatePayment should return null if invalid payload is provided', () => {
+    const result = calculatePayment([{ sheetId: '' }], mockLogger)
 
-  it('calculatePayment should throw a bad request error if no land actions is provided', () => {
-    expect(() => calculatePayment(null, mockLogger)).toThrow(Boom.Boom)
-    let error
-    try {
-      calculatePayment(null, mockLogger)
-    } catch (err) {
-      error = err
-    }
-    expect(error.isBoom).toBe(true)
-    expect(error.output.payload.message).toBe('landActions are required')
+    expect(result).toBeNull()
   })
 
-  it('should return calculated payments for given valid land actions', async () => {
+  it('should return calculated payments for given valid land actions', () => {
     const expectedPayment = {
       payment: {
         total: 100.98
       }
     }
 
-    const result = await calculatePayment(landActions, mockLogger)
+    const result = calculatePayment(mockLandActions, mockLogger)
 
     expect(result).toEqual(expectedPayment)
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RPS-647

This pr changes the format of the error messages for the actions/validate endpoint
- Includes an update to controllers for actionvalidate and paymentcalculate,  moving http related stuff to controllers away from services
- tests have been updated to new style, using server.inject

The error messages for the validate endpoint are now in this format, so will break the ui/tests.

```
{
    "message": "success",
.   "valid": false,
    "errorMessages": [
        { "code": "CSAM1", "description": CSAM1 is exceeding max limit 100" },
.       { "code": "CSAM2", "description": CSAM2 is not compatible with CSAM1" }
    ],
}
```
