### PR TITLE
RPS 659: Move migration process to liquibase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-SEED_DB=true
+SEED_MONGODB=true
 NODE_ENV=local
 DISABLE_POSTGRES=false
 POSTGRES_HOST=land-grants-api.cluster-crfypi4jpal8.eu-west-2.rds.amazonaws.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Publish Database Schema
+        uses: DEFRA/cdp-build-action/publish-db-migrations@main
+        with:
+          path: ./changelog
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Test Coverage Reports
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Refer: .env.example
 If you have issue with .env file set env variables in package.json scripts
 
 ```
- "dev": "NODE_ENV=local SEED_DB=true DISABLE_POSTGRES=false npm run server:watch",
+ "dev": "NODE_ENV=local SEED_MONGODB=true DISABLE_POSTGRES=false npm run server:watch",
 ```
 
 3. run
@@ -120,10 +120,6 @@ npm run dev
 
 4. Successful data load message in the console on start-up
 
-- Successfully loaded postgres data 001-create-schema.sql into Postgis
-- Successfully loaded postgres data 002-create-land-table.sql into Postgis
-- Successfully loaded postgres data 003-create-land-covers-table.sql into Postgis
-- Successfully loaded postgres data 004-create-moorland-designations-table.sql into Postgis
 - Successfully loaded postgres data land-parcels-data.sql into Postgis
 - Successfully loaded postgres data land-covers-data.sql into Postgis
 - Successfully loaded postgres data moorland-designations-data.sql into Postgis

--- a/changelog/db.changelog-1.0.xml
+++ b/changelog/db.changelog-1.0.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+  <changeSet id="create-land-schema" author="system">
+    <sql>CREATE SCHEMA IF NOT EXISTS land;</sql>
+  </changeSet>
+
+  <changeSet id="create-land-covers-table" author="system">
+    <createTable tableName="land_covers" schemaName="land">
+      <column name="id" type="SERIAL" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="parcel_id" type="TEXT"/>
+      <column name="sheet_id" type="TEXT"/>
+      <column name="land_cover_class_code" type="TEXT"/>
+      <column name="is_linear_feature" type="BOOLEAN"/>
+      <column name="area_sqm" type="NUMERIC"/>
+      <column name="geom" type="GEOMETRY"/>
+      <column name="last_updated" type="DATE"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create-land-parcels-table" author="system">
+    <createTable tableName="land_parcels" schemaName="land">
+      <column name="id" type="SERIAL" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="parcel_id" type="TEXT"/>
+      <column name="sheet_id" type="TEXT"/>
+      <column name="area_sqm" type="NUMERIC"/>
+      <column name="geom" type="GEOMETRY"/>
+      <column name="last_updated" type="DATE"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create-moorland-designations-table" author="system">
+    <createTable tableName="moorland_designations" schemaName="land">
+      <column name="id" type="SERIAL" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="lfa_moor_id" type="NUMERIC"/>
+      <column name="name" type="TEXT"/>
+      <column name="ref_code" type="TEXT"/>
+      <column name="geom" type="GEOMETRY"/>
+      <column name="last_updated" type="DATE"/>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+  <include  file="changelog/db.changelog-1.0.xml"/>
+</databaseChangeLog>

--- a/compose.migrate.yml
+++ b/compose.migrate.yml
@@ -1,0 +1,50 @@
+x-common-migration: &common-migration
+  POSTGRES_HOST: ${POSTGRES_HOST:-land-grants-backend-postgres}
+  SCHEMA_ROLE: ${POSTGRES_SCHEMA_ROLE:-land_grants_api}
+  SCHEMA_NAME: ${POSTGRES_SCHEMA_NAME:-public}
+
+x-common-postgres: &common-postgres
+  POSTGRES_PORT: 5432
+  POSTGRES_DB: ${POSTGRES_DB:-land_grants_api}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-land_grants_api}
+  POSTGRES_USER: ${POSTGRES_USER:-land_grants_api}
+
+services:
+  database-up:
+    image: liquibase/liquibase:4.31-alpine
+    environment:
+      << : [*common-postgres, *common-migration]
+    entrypoint: >
+      sh -c "/scripts/migration/database-up"
+    depends_on:
+      - land-grants-backend-postgres
+    volumes:
+      - ./changelog:/liquibase/changelog
+      - ./scripts:/scripts
+
+  database-down:
+    image: liquibase/liquibase:4.31-alpine
+    environment:
+      << : [*common-postgres, *common-migration]
+    entrypoint: >
+      sh -c "/scripts/migration/database-down"
+    depends_on:
+      - land-grants-backend-postgres
+    volumes:
+      - ./changelog:/liquibase/changelog
+      - ./scripts:/scripts
+
+  land-grants-backend-postgres:
+    image: postgis/postgis:16-3.4
+    environment: *common-postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+
+networks:
+  cdp-tenant:
+    external: true

--- a/compose.yml
+++ b/compose.yml
@@ -41,15 +41,15 @@ services:
       - mongodb-data:/data
     restart: always
 
-  postgres:
+  land-grants-backend-postgres:
     image: postgis/postgis:16-3.4
     restart: always
     ports:
       - 5432:5432
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=p0stgr@s
-      - POSTGRES_DB=postgres
+      - POSTGRES_USER=land_grants_api
+      - POSTGRES_PASSWORD=land_grants_api
+      - POSTGRES_DB=land_grants_api
     networks:
       - cdp-tenant
     volumes:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:server",
     "build:server": "NODE_ENV=production babel --delete-dir-on-start --ignore \"**/*.test.js\" --ignore \"**/__fixtures__\" --ignore \"**/test-helpers\" --copy-files --no-copy-ignored --out-dir ./.server ./src",
     "docker:dev": "NODE_ENV=development npm run server:watch",
-    "dev": "NODE_ENV=local SEED_DB=true npm run server:watch",
+    "dev": "NODE_ENV=local SEED_MONGODB=true npm run server:watch",
     "dev:debug": "npm run server:debug",
     "format": "prettier --write \"src/**/*.js\" \"**/*.{js,cjs,md,json,config.js,test.js,graphql.js}\"",
     "format:check": "prettier --check \"src/**/*.js\" \"**/*.{js,cjs,md,json,config.js,test.js,graphql.js}\"",

--- a/scripts/migration/database-down
+++ b/scripts/migration/database-down
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "db update on $POSTGRES_HOST $SCHEMA_NAME as $SCHEMA_USERNAME"
+/liquibase/liquibase \
+--driver=org.postgresql.Driver \
+--changeLogFile=/changelog/db.changelog.xml \
+--url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB \
+--username="$SCHEMA_USERNAME" --password="$SCHEMA_PASSWORD" --defaultSchemaName="$SCHEMA_NAME" \
+rollback v0.0.0

--- a/scripts/migration/database-up
+++ b/scripts/migration/database-up
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "db update on $POSTGRES_HOST:$POSTGRES_PORT $SCHEMA_NAME as $POSTGRES_USER"
+
+/liquibase/liquibase \
+--driver=org.postgresql.Driver \
+--changeLogFile=/changelog/db.changelog.xml \
+--url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB \
+--username="$POSTGRES_USER" --password="$POSTGRES_PASSWORD" --defaultSchemaName="$SCHEMA_NAME" \
+update

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/.." || return; pwd)"
+
+cd "${projectRoot}"
+
+docker compose down
+docker compose -f compose.migrate.yml down
+docker compose -f compose.migrate.yml run --rm database-up
+
+docker compose \
+  -f compose.yml \
+  up $@

--- a/src/api/common/helpers/mongoose.js
+++ b/src/api/common/helpers/mongoose.js
@@ -26,7 +26,7 @@ export const mongooseDb = {
       server.decorate('server', 'mongooseDb', mongoose.connection)
 
       // Seed the database if required
-      if (config.get('seedDb') === true) {
+      if (config.get('seedMongoDb') === true) {
         server.logger.info('Seeding database')
         await seedDatabase(server.logger)
       }

--- a/src/api/common/helpers/postgres.js
+++ b/src/api/common/helpers/postgres.js
@@ -113,7 +113,6 @@ export const postgresDb = {
     passwordForLocalDev: config.get('postgres.passwordForLocalDev'),
     isLocal: config.get('isLocal'),
     region: config.get('postgres.region'),
-    disablePostgres: config.get('disablePostgres'),
-    seed: config.get('seedDb')
+    disablePostgres: config.get('disablePostgres')
   }
 }

--- a/src/api/common/helpers/postgres.js
+++ b/src/api/common/helpers/postgres.js
@@ -68,22 +68,6 @@ export const postgresDb = {
         client.release()
 
         if (options.isLocal) {
-          await loadPostgresData('001-create-schema.sql', pool, server.logger)
-          await loadPostgresData(
-            '002-create-land-table.sql',
-            pool,
-            server.logger
-          )
-          await loadPostgresData(
-            '003-create-land-covers-table.sql',
-            pool,
-            server.logger
-          )
-          await loadPostgresData(
-            '004-create-moorland-designations-table.sql',
-            pool,
-            server.logger
-          )
           await loadPostgresData('land-parcels-data.sql', pool, server.logger)
           await loadPostgresData('land-covers-data.sql', pool, server.logger)
           await loadPostgresData(

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -143,11 +143,11 @@ const config = convict({
     default: 'land-grants-api',
     env: 'MONGO_DATABASE'
   },
-  seedDb: {
+  seedMongoDb: {
     doc: 'Seed the database',
     format: Boolean,
     default: false,
-    env: 'SEED_DB'
+    env: 'SEED_MONGODB'
   },
   httpProxy: {
     doc: 'HTTP Proxy',


### PR DESCRIPTION
To run postres locally, run `./script/start`. 

This will 
- remove previous docker compose containers 
- start up liquibase and postgress instance to run migrations against
- start the default compose.yml

Eventually, we will update `npm run dev` to use `./scripts/start` 
