### PR TITLE
Postgres connection with token on connect

### DIFF
--- a/src/api/common/helpers/postgres.js
+++ b/src/api/common/helpers/postgres.js
@@ -9,7 +9,6 @@ const DEFAULT_PORT = 5432
 class SecurePool extends Pool {
   constructor(options) {
     super({
-      max: 10,
       host: options.host,
       port: options.port,
       database: options.database,

--- a/src/api/common/helpers/postgres.js
+++ b/src/api/common/helpers/postgres.js
@@ -35,8 +35,10 @@ class SecurePool extends Pool {
     this.originalConnect = super.connect.bind(this)
   }
 
-  connect() {
-    this.options.password = this.options.passwordForLocalDev
+  async connect() {
+    this.options.password = this.options.isLocal
+      ? this.options.passwordForLocalDev
+      : await this.signer.getAuthToken()
     return this.originalConnect()
   }
 }


### PR DESCRIPTION
Implements a solution that gets a new token using rds signer for remote databases, locally just uses a password. 
The solution is to override the connect method, of the `pg` Pool class, and reimplement the connect method, calling the original method after setting the password