### PR TITLE
Add grant permissions changelog for land_grants_api

### DIFF
--- a/changelog/db.changelog-1.2.xml
+++ b/changelog/db.changelog-1.2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+
+  <changeSet id="grant-select-for-land-covers" author="system">
+    <sql>GRANT select on land_parcels to land_grants_api;</sql>
+  </changeSet>
+
+  <changeSet id="grant-select-for-land-parcels" author="system">
+    <sql>GRANT select on land_covers to land_grants_api;</sql>
+  </changeSet>
+
+  <changeSet id="grant-select-for-moorland-designations" author="system">
+    <sql>GRANT select on moorland_designations to land_grants_api;</sql>
+  </changeSet>
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -6,4 +6,5 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
   <include  file="changelog/db.changelog-1.0.xml"/>
   <include  file="changelog/db.changelog-1.1.xml"/>
+  <include  file="changelog/db.changelog-1.2.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This commit introduces a new Liquibase changelog file to grant SELECT permissions on land_parcels, land_covers, and moorland_designations to the land_grants_api user. The changelog is included in the main changelog configuration for execution.