### PR TITLE
Remove guidanceURLs from the codebase

### DIFF
--- a/src/api/actions/fixtures/index.js
+++ b/src/api/actions/fixtures/index.js
@@ -6,7 +6,6 @@ const mockActions = [
     startDate: '2025-01-01',
     code: 'CMOR1',
     description: 'CMOR1: Assess moorland and produce a written record',
-    guidanceUrl: 'https://www.gov.uk/guidance/cmor1',
     applicationUnitOfMeasurement,
     payment: {
       ratePerUnitGbp: 10.6,
@@ -48,7 +47,6 @@ const mockMultipleActions = [
     startDate: '2025-01-01',
     code: 'UPL1',
     description: 'UPL1: Moderate livestock grazing on moorland',
-    guidanceUrl: 'https://www.gov.uk/guidance/upl1',
     applicationUnitOfMeasurement,
     payment: {
       'rate-per-unit-gbp': 20
@@ -86,7 +84,6 @@ const mockMultipleActions = [
     startDate: '2025-01-01',
     code: 'CMOR1',
     description: 'CMOR1: Assess moorland and produce a written record',
-    guidanceUrl: 'https://www.gov.uk/guidance/cmor1',
     applicationUnitOfMeasurement,
     payment: {
       ratePerUnitGbp: 10.6,
@@ -125,7 +122,6 @@ const mockMultipleActions = [
     startDate: '2025-01-01',
     code: 'UPL2',
     description: 'UPL2: Low livestock grazing on moorland',
-    guidanceUrl: 'https://www.gov.uk/guidance/upl2',
     applicationUnitOfMeasurement,
     payment: {
       'rate-per-unit-gbp': 53

--- a/src/api/actions/models/action.model.js
+++ b/src/api/actions/models/action.model.js
@@ -9,7 +9,6 @@ const schema = new mongoose.Schema(
     code: { type: String, required: true },
     description: { type: String, required: true },
     applicationUnitOfMeasurement: { type: String, required: true },
-    guidanceUrl: { type: String, required: true },
     payment: {
       ratePerUnitGbp: { type: Number },
       ratePerAgreementPerYearGbp: { type: Number }

--- a/src/api/common/helpers/seed-data/action-data.js
+++ b/src/api/common/helpers/seed-data/action-data.js
@@ -7,8 +7,6 @@ export default [
     code: 'CMOR1',
     description: 'CMOR1: Assess moorland and produce a written record',
     applicationUnitOfMeasurement,
-    guidanceUrl:
-      'https://www.gov.uk/find-funding-for-land-or-farms/cmor1-assess-moorland-and-produce-a-written-record',
     payment: {
       ratePerUnitGbp: 10.6,
       ratePerAgreementPerYearGbp: 272
@@ -47,8 +45,6 @@ export default [
     code: 'UPL1',
     description: 'UPL1: Moderate livestock grazing on moorland',
     applicationUnitOfMeasurement,
-    guidanceUrl:
-      'https://www.gov.uk/find-funding-for-land-or-farms/upl1-moderate-livestock-grazing-on-moorland',
     payment: {
       ratePerUnitGbp: 20
     },
@@ -86,8 +82,6 @@ export default [
     code: 'UPL2',
     description: 'UPL2: Low livestock grazing on moorland',
     applicationUnitOfMeasurement,
-    guidanceUrl:
-      'https://www.gov.uk/find-funding-for-land-or-farms/upl2-low-livestock-grazing-on-moorland',
     payment: {
       ratePerUnitGbp: 53
     },
@@ -125,8 +119,6 @@ export default [
     code: 'UPL3',
     description: 'UPL3: Limited livestock grazing on moorland',
     applicationUnitOfMeasurement,
-    guidanceUrl:
-      'https://www.gov.uk/find-funding-for-land-or-farms/upl3-limited-livestock-grazing-on-moorland',
     payment: {
       ratePerUnitGbp: 66
     },
@@ -165,7 +157,6 @@ export default [
     description:
       'UPL4: Keep cattle and ponies on moorland supplement (minimum 30% GLU)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -180,7 +171,6 @@ export default [
     description:
       'UPL5: Keep cattle and ponies on moorland supplement (minimum 70% GLU)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -195,7 +185,6 @@ export default [
     description:
       'UPL6: Keep cattle and ponies on moorland supplement (100% GLU)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -210,7 +199,6 @@ export default [
     description:
       'UPL7: Shepherding livestock on moorland (no required stock removal period)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -225,7 +213,6 @@ export default [
     description:
       'UPL8: Shepherding livestock on moorland (remove stock for at least 4 months)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -240,7 +227,6 @@ export default [
     description:
       'UPL9: Shepherding livestock on moorland (remove stock for at least 6 months)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -255,7 +241,6 @@ export default [
     description:
       'SPM4: Keep native breeds on extensively managed habitats supplement (50-80%)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0
@@ -270,7 +255,6 @@ export default [
     description:
       'SPM5: Keep native breeds on extensively managed habitats supplement (more than 80%)',
     applicationUnitOfMeasurement,
-    guidanceUrl: 'NA',
     payment: {
       ratePerUnitGbp: 0,
       ratePerAgreementPerYearGbp: 0

--- a/src/api/parcel/controllers/parcels.controller.test.js
+++ b/src/api/parcel/controllers/parcels.controller.test.js
@@ -68,7 +68,6 @@ describe('Parcels controller', () => {
         {
           code: 'CMOR1',
           description: 'CMOR1: Assess moorland and produce a written record',
-          guidanceUrl: 'https://www.gov.uk/guidance/cmor1',
           availableArea: {
             unit: 'ha',
             value: 0.03

--- a/src/api/parcel/fixtures/index.js
+++ b/src/api/parcel/fixtures/index.js
@@ -35,7 +35,6 @@ const mockParcelWithActions = {
       {
         code: 'CMOR1',
         description: 'CMOR1: Assess moorland and produce a written record',
-        guidanceUrl: 'https://www.gov.uk/guidance/cmor1',
         availableArea: {
           unit: applicationUnitOfMeasurement,
           value: applicationUnitOfMeasurement === 'sqm' ? 200 : 0.02

--- a/src/api/parcel/schema/parcel.schema.js
+++ b/src/api/parcel/schema/parcel.schema.js
@@ -15,7 +15,6 @@ const parcelActionsSchema = Joi.object({
       Joi.object({
         code: Joi.string().required(),
         description: Joi.string().required(),
-        guidanceUrl: Joi.string().required(),
         availableArea: Joi.object({
           unit: Joi.string().valid(applicationUnitOfMeasurement).required(),
           value: Joi.number().min(0).required()
@@ -38,8 +37,7 @@ const availableAreaSchema = Joi.object({
 const actionSchema = Joi.object({
   code: Joi.string().required(),
   description: Joi.string().required(),
-  availableArea: availableAreaSchema.optional(),
-  guidanceUrl: Joi.string().required()
+  availableArea: availableAreaSchema.optional()
 })
 
 const parcelSchema = Joi.object({

--- a/src/api/parcel/transformers/parcelActions.transformer.js
+++ b/src/api/parcel/transformers/parcelActions.transformer.js
@@ -25,8 +25,7 @@ function actionTransformer(action, totalAvailableArea) {
     availableArea:
       totalAvailableArea || totalAvailableArea === 0
         ? sizeTransformer(totalAvailableArea)
-        : undefined,
-    guidanceUrl: action.guidanceUrl
+        : undefined
   }
 }
 

--- a/src/api/parcel/transformers/parcelActions.transformer.test.js
+++ b/src/api/parcel/transformers/parcelActions.transformer.test.js
@@ -21,8 +21,7 @@ describe('actionTransformer', () => {
   test('should transform action with available area', () => {
     const action = {
       code: 'ACTION1',
-      description: 'Test Action',
-      guidanceUrl: 'https://www.gov.uk'
+      description: 'Test Action'
     }
     const totalAvailableArea = 500
 
@@ -34,16 +33,14 @@ describe('actionTransformer', () => {
       availableArea: {
         unit: 'ha',
         value: 500
-      },
-      guidanceUrl: 'https://www.gov.uk'
+      }
     })
   })
 
   test('should transform action without available area when totalAvailableArea is null', () => {
     const action = {
       code: 'ACTION1',
-      description: 'Test Action',
-      guidanceUrl: 'https://www.gov.uk'
+      description: 'Test Action'
     }
     const totalAvailableArea = null
 
@@ -52,16 +49,14 @@ describe('actionTransformer', () => {
     expect(result).toEqual({
       code: 'ACTION1',
       description: 'Test Action',
-      availableArea: undefined,
-      guidanceUrl: 'https://www.gov.uk'
+      availableArea: undefined
     })
   })
 
   test('should transform action without available area when totalAvailableArea is undefined', () => {
     const action = {
       code: 'ACTION1',
-      description: 'Test Action',
-      guidanceUrl: 'https://www.gov.uk'
+      description: 'Test Action'
     }
 
     const result = actionTransformer(action)
@@ -69,16 +64,14 @@ describe('actionTransformer', () => {
     expect(result).toEqual({
       code: 'ACTION1',
       description: 'Test Action',
-      availableArea: undefined,
-      guidanceUrl: 'https://www.gov.uk'
+      availableArea: undefined
     })
   })
 
   test('should transform action with available area when totalAvailableArea is 0', () => {
     const action = {
       code: 'ACTION1',
-      description: 'Test Action',
-      guidanceUrl: 'https://www.gov.uk'
+      description: 'Test Action'
     }
     const totalAvailableArea = 0
 
@@ -90,8 +83,7 @@ describe('actionTransformer', () => {
       availableArea: {
         unit: 'ha',
         value: 0
-      },
-      guidanceUrl: 'https://www.gov.uk'
+      }
     })
   })
 })


### PR DESCRIPTION
In early designs it looked like the ui would need guidance URLs for each action, but this was not the case. This commit removes the guidanceURLs from the codebase, including the fixtures, models, and transformers and updates the tests accordingly.