### PR TITLE
Add optional startDate param to payments controller

### DIFF
--- a/src/api/actions/schema/payment-calculate.schema.js
+++ b/src/api/actions/schema/payment-calculate.schema.js
@@ -1,0 +1,24 @@
+import Joi from 'joi'
+
+const paymentCalculateSchema = Joi.object({
+  startDate: Joi.string().optional(),
+  landActions: Joi.array()
+    .items(
+      Joi.object({
+        sheetId: Joi.string().required(),
+        parcelId: Joi.string().required(),
+        sbi: Joi.number().integer().required(),
+        actions: Joi.array()
+          .items(
+            Joi.object({
+              code: Joi.string().required(),
+              quantity: Joi.number().required()
+            })
+          )
+          .required()
+      })
+    )
+    .required()
+})
+
+export { paymentCalculateSchema }

--- a/src/api/payment/controllers/payment-calculate.controller.js
+++ b/src/api/payment/controllers/payment-calculate.controller.js
@@ -1,5 +1,4 @@
 import Boom from '@hapi/boom'
-import { landActionSchema } from '~/src/api/actions/schema/action-validation.schema.js'
 import { statusCodes } from '~/src/api/common/constants/status-codes.js'
 import {
   errorResponseSchema,
@@ -10,6 +9,7 @@ import {
   getPaymentCalculationDataRequirements,
   getPaymentCalculationForParcels
 } from '~/src/payment-calculation/paymentCalculation.js'
+import { paymentCalculateSchema } from '../../actions/schema/payment-calculate.schema.js'
 
 /**
  * PaymentsCalculateController
@@ -22,7 +22,7 @@ const PaymentsCalculateController = {
     notes:
       'Calculates payment amounts for land-based actions. Used to determine annual payments based on action type and land area.',
     validate: {
-      payload: landActionSchema
+      payload: paymentCalculateSchema
     },
     response: {
       status: {
@@ -35,7 +35,7 @@ const PaymentsCalculateController = {
 
   handler: async (request, h) => {
     try {
-      const { landActions } = request.payload
+      const { landActions, startDate } = request.payload
 
       request.logger.info(
         `Controller calculating land actions payment ${landActions}`
@@ -77,7 +77,8 @@ const PaymentsCalculateController = {
       const calculateResponse = getPaymentCalculationForParcels(
         landActions,
         enabledActions,
-        totalDurationYears
+        totalDurationYears,
+        startDate
       )
 
       if (!calculateResponse) {

--- a/src/payment-calculation/paymentCalculation.js
+++ b/src/payment-calculation/paymentCalculation.js
@@ -26,12 +26,14 @@ export const getPaymentCalculationDataRequirements = async (
  * @param {Array<PaymentParcel>} parcels
  * @param {Array<Action>} actions
  * @param {number} durationYears
+ * @param {string} startDate
  * @returns {PaymentCalculationResponse}
  */
 export const getPaymentCalculationForParcels = (
   parcels,
   actions,
-  durationYears
+  durationYears,
+  startDate
 ) => {
   const frequency = 'Quarterly'
 
@@ -48,7 +50,7 @@ export const getPaymentCalculationForParcels = (
 
   // generate date schedule
   const { agreementStartDate, agreementEndDate, schedule } =
-    generatePaymentSchedule(new Date(), durationYears, frequency)
+    generatePaymentSchedule(startDate ?? new Date(), durationYears, frequency)
 
   // calculate payments based on schedule and parcel/agreement items amounts
   const payments = calculateScheduledPayments(

--- a/src/payment-calculation/paymentCalculation.test.js
+++ b/src/payment-calculation/paymentCalculation.test.js
@@ -162,4 +162,130 @@ describe('getPaymentCalculationForParcels', () => {
 
     expect(response).toEqual(expectedResponse)
   })
+
+  it('should return a response based on startDate if provided', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2025, 6, 2))
+    const durationYears = 1
+
+    const parcels = [
+      {
+        sheetId: 'SD5253',
+        parcelId: '5484',
+        actions: [
+          {
+            code: 'CMOR1',
+            quantity: 0.34
+          }
+        ]
+      },
+      {
+        sheetId: 'SD5111',
+        parcelId: '2222',
+        actions: [
+          {
+            code: 'CSAM1',
+            quantity: 1.45
+          }
+        ]
+      }
+    ]
+
+    const expectedLineItem = [
+      {
+        parcelItemId: 1,
+        paymentPence: 90
+      },
+      {
+        parcelItemId: 2,
+        paymentPence: 217
+      },
+      {
+        agreementLevelItemId: 1,
+        paymentPence: 6800
+      },
+      {
+        agreementLevelItemId: 2,
+        paymentPence: 2425
+      }
+    ]
+    const expectedResponse = {
+      agreementStartDate: '2026-02-01',
+      agreementEndDate: '2027-02-01',
+      frequency: 'Quarterly',
+      agreementTotalPence: 38130,
+      annualTotalPence: 38130, // -- Is this right? If this isn't divisible by 3 (or X years) then one year will be different. Should this be an array?
+
+      parcelItems: {
+        1: {
+          code: 'CMOR1',
+          description: 'Assess moorland and produce a written record',
+          version: 1,
+          unit: 'ha',
+          quantity: 0.34,
+          rateInPence: 1060,
+          annualPaymentPence: 360,
+          sheetId: 'SD5253',
+          parcelId: '5484'
+        },
+        2: {
+          code: 'CSAM1',
+          description:
+            'Assess soil, test soil organic matter and produce a soil management plan',
+          version: 1,
+          unit: 'ha',
+          quantity: 1.45,
+          rateInPence: 600,
+          annualPaymentPence: 870,
+          sheetId: 'SD5111',
+          parcelId: '2222'
+        }
+      },
+      agreementLevelItems: {
+        1: {
+          code: 'CMOR1',
+          description: 'Assess moorland and produce a written record',
+          version: 1,
+          annualPaymentPence: 27200
+        },
+        2: {
+          code: 'CSAM1',
+          description:
+            'Assess soil, test soil organic matter and produce a soil management plan',
+          version: 1,
+          annualPaymentPence: 9700
+        }
+      },
+      payments: [
+        {
+          lineItems: expectedLineItem,
+          paymentDate: '2026-05-05',
+          totalPaymentPence: 9534
+        },
+        {
+          lineItems: expectedLineItem,
+          paymentDate: '2026-08-05',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: expectedLineItem,
+          paymentDate: '2026-11-05',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: expectedLineItem,
+          paymentDate: '2027-02-05',
+          totalPaymentPence: 9532
+        }
+      ]
+    }
+
+    const response = getPaymentCalculationForParcels(
+      parcels,
+      mockEnabledActions,
+      durationYears,
+      '2026-01-01'
+    )
+
+    expect(response).toEqual(expectedResponse)
+  })
 })


### PR DESCRIPTION
This PR adds an optional 'startDate' param to the /payments/calculate request, so you can pass:

```
{
  "startDate": "2025-12-31",
  "landActions": [
    {
      "sheetId": "SD6743",
      "parcelId": "8083",
      "sbi": "106284736",
      "actions": [
        {
          "code": "UPL1",
          "quantity":4.53411078
        }
      ]
    }
  ]
}
```

and get a payments calculation response based on the start date provided. If not specified, start date will be today.