### PR TITLE
Remove unused actions.availableArea field

### DIFF
--- a/src/api/parcel/controllers/parcels.controller.test.js
+++ b/src/api/parcel/controllers/parcels.controller.test.js
@@ -352,7 +352,7 @@ describe('Parcels controller', () => {
         method: 'POST',
         url: `/parcels`,
         payload: {
-          fields: ['actions.availableArea'],
+          fields: ['actions'],
           parcelIds: [`${sheetId}-${parcelId}`],
           plannedActions: []
         }

--- a/src/api/parcel/schema/parcel.schema.js
+++ b/src/api/parcel/schema/parcel.schema.js
@@ -58,14 +58,7 @@ const parcelSchema = Joi.object({
 const parcelsSchema = Joi.object({
   parcelIds: Joi.array().items(parcelIdSchema).required(),
   fields: Joi.array()
-    .items(
-      Joi.string().valid(
-        'size',
-        'actions',
-        'actions.availableArea',
-        'actions.results'
-      )
-    )
+    .items(Joi.string().valid('size', 'actions', 'actions.results'))
     .required(),
   plannedActions: Joi.array()
     .items(

--- a/src/api/parcel/schema/parcel.schema.test.js
+++ b/src/api/parcel/schema/parcel.schema.test.js
@@ -160,19 +160,10 @@ describe('Parcel Schema Validation', () => {
       expect(result.error).toBeUndefined()
     })
 
-    it('should validate with actions.availableArea field', () => {
-      const valid = {
-        ...validParcelsRequest,
-        fields: ['actions.availableArea']
-      }
-      const result = parcelsSchema.validate(valid)
-      expect(result.error).toBeUndefined()
-    })
-
     it('should validate with all valid fields', () => {
       const valid = {
         ...validParcelsRequest,
-        fields: ['size', 'actions', 'actions.availableArea']
+        fields: ['size', 'actions', 'actions.results']
       }
       const result = parcelsSchema.validate(valid)
       expect(result.error).toBeUndefined()

--- a/src/db-tests/getParcels.db.test.js
+++ b/src/db-tests/getParcels.db.test.js
@@ -40,7 +40,7 @@ describe('Calculate available area', () => {
       {
         payload: {
           parcelIds: ['SD6743-7268'],
-          fields: ['size', 'actions.availableArea', 'actions.results'],
+          fields: ['size', 'actions', 'actions.results'],
           plannedActions: []
         },
         logger,
@@ -127,7 +127,7 @@ describe('Calculate available area', () => {
       {
         payload: {
           parcelIds: ['SD6743-7268'],
-          fields: ['size', 'actions.availableArea', 'actions.results'],
+          fields: ['size', 'actions', 'actions.results'],
           plannedActions: [{ actionCode: 'CMOR1', quantity: 0.1, unit: 'ha' }]
         },
         logger,
@@ -239,7 +239,7 @@ describe('Calculate available area', () => {
       {
         payload: {
           parcelIds: ['SD6743-7268'],
-          fields: ['size', 'actions.availableArea', 'actions.results'],
+          fields: ['size', 'actions', 'actions.results'],
           plannedActions: [
             { actionCode: 'UPL1', quantity: 0.1, unit: 'ha' },
             { actionCode: 'UPL2', quantity: 0.2, unit: 'ha' }

--- a/src/db-tests/parcelController.integration.test.js
+++ b/src/db-tests/parcelController.integration.test.js
@@ -48,7 +48,7 @@ describe('Calculate available area with agreements', () => {
       {
         payload: {
           parcelIds: ['SD6743-7268'],
-          fields: ['size', 'actions.availableArea', 'actions.results'],
+          fields: ['size', 'actions', 'actions.results'],
           plannedActions: []
         },
         logger,
@@ -169,7 +169,7 @@ describe('Calculate available area with agreements', () => {
       {
         payload: {
           parcelIds: ['SD6743-7268'],
-          fields: ['size', 'actions.availableArea', 'actions.results'],
+          fields: ['size', 'actions', 'actions.results'],
           plannedActions: [{ actionCode: 'UPL2', quantity: 0.1, unit: 'ha' }]
         },
         logger,


### PR DESCRIPTION
This PR removes an unused field that used to exist on the parcels controller: 'actions.availableArea'.