### PR TITLE
map for action validation results

### DIFF
--- a/src/api/actions/controllers/actions-validation.controller.js
+++ b/src/api/actions/controllers/actions-validation.controller.js
@@ -9,6 +9,7 @@ import {
   internalServerErrorResponseSchema
 } from '~/src/api/common/schema/index.js'
 import { validateLandParcelActions } from '../service/land-parcel-validation.service.js'
+import { mapRuleResult } from '../transformers/validation-results.transformer.js'
 
 /**
  * LandActionsValidateController
@@ -68,7 +69,7 @@ const LandActionsValidateController = {
         .response({
           message: 'success',
           valid: results.every((r) => r.passed),
-          errorMessages: results.filter((r) => !r.passed)
+          errorMessages: results.filter((r) => !r.passed).map(mapRuleResult)
         })
         .code(statusCodes.ok)
     } catch (error) {

--- a/src/api/actions/service/land-parcel-validation.service.js
+++ b/src/api/actions/service/land-parcel-validation.service.js
@@ -9,7 +9,7 @@ import { validateLandAction } from '~/src/api/actions/service/action-validation.
  * Validate the actions for a land parcel
  * @param {{ sheetId: string, parcelId: string, actions: Action[] }} landAction - The land action
  * @param {{ logger: object, server: { postgresDb: object } }} request - The request object
- * @returns {Promise<{ code: string, description: string, sheetId: string, parcelId: string, passed: boolean, rule: string }[]>} The validation result
+ * @returns {Promise<ValidationResult[]>} The validation result
  */
 export const validateLandParcelActions = async (landAction, request) => {
   const landParcels = await getLandData(
@@ -80,4 +80,5 @@ export const validateLandParcelActions = async (landAction, request) => {
 
 /**
  * @import { Action } from '../action.d.js'
+ * @import { ValidationResult } from '~/src/api/common/common.d.js'
  */

--- a/src/api/actions/transformers/validation-results.transformer.js
+++ b/src/api/actions/transformers/validation-results.transformer.js
@@ -1,0 +1,18 @@
+/**
+ *
+ * @param {ValidationResult} validationResult
+ * @returns {{code: string, description: string, sheetId: string, parcelId: string, passed: boolean}}
+ */
+export const mapRuleResult = (validationResult) => {
+  return {
+    code: validationResult.code,
+    description: validationResult.description,
+    sheetId: validationResult.sheetId,
+    parcelId: validationResult.parcelId,
+    passed: validationResult.passed
+  }
+}
+
+/**
+ * @import { ValidationResult } from '~/src/api/common/common.d.js'
+ */

--- a/src/api/common/common.d.js
+++ b/src/api/common/common.d.js
@@ -3,3 +3,13 @@
  * @property {string} sheetId
  * @property {string} parcelId
  */
+
+/**
+ * @typedef {object} ValidationResult
+ * @property {string} code
+ * @property {string} description
+ * @property {string} sheetId
+ * @property {string} parcelId
+ * @property {boolean} passed
+ * @property {string} rule
+ */

--- a/src/rules-engine/rulesEngine.js
+++ b/src/rules-engine/rulesEngine.js
@@ -24,7 +24,5 @@ export const executeRules = (rules, application, actionRules = []) => {
 
 /**
  * @import {ActionRule} from '../api/actions/action.d.js'
- */
-/**
  * @import {RulesResult} from '../rules-engine/rules.d.js'
  */


### PR DESCRIPTION
As part of the validation refactoring we now return the rule name from validateLandParcelActions function, this removes it from the actions/validate endpoint as it not required and breaks schema validaiton