### PR TITLE
Pact test version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "land-grants-api",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Land grants API",
   "main": ".server/index.js",
   "type": "module",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,6 +2,7 @@ import convict from 'convict'
 import 'dotenv/config'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import packageJson from '~/package.json' with { type: 'json' }
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -14,7 +15,7 @@ const config = convict({
     doc: 'The service version, this variable is injected into your docker container in CDP environments',
     format: String,
     nullable: true,
-    default: '1.0.0',
+    default: packageJson.version,
     env: 'SERVICE_VERSION'
   },
   env: {

--- a/src/contract-tests/provider.test.js
+++ b/src/contract-tests/provider.test.js
@@ -1,4 +1,6 @@
 import { env } from 'node:process'
+
+import { config } from '~/src/config/index.js'
 import dotenv from 'dotenv'
 import { Verifier } from '@pact-foundation/pact'
 import { getLandData } from '~/src/api/parcel/queries/getLandData.query.js'
@@ -59,7 +61,7 @@ const pactVerifierOptions = {
   pactBrokerUsername: env.PACT_BROKER_USERNAME,
   pactBrokerPassword: env.PACT_BROKER_PASSWORD,
   publishVerificationResult: true,
-  providerVersion: process.env.GIT_COMMIT ?? '1.0.0',
+  providerVersion: config.get('serviceVersion') ?? '1.0.0',
 
   stateHandlers: {
     'has a parcel with ID': ({ sheetId, parcelId }) => {


### PR DESCRIPTION
The PACT provider version was being reported to the broker a 1.0.0, we now send the version from package.json.

<img width="1188" height="197" alt="image" src="https://github.com/user-attachments/assets/ebd09d9c-8e1a-4a31-b026-e94ad2e23952" />
