### PR TITLE
GSPS-353: Add SQS consumer for grants-config-broker updates 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ INGEST_ENDPOINT=https://cdp-uploader.dev.cdp-int.defra.cloud/initiate
 INGEST_CALLBACK=https://land-grants-api.dev.cdp-int.defra.cloud/cdp-uploader-callback
 GRANTS_UI_HOST=https://grants-ui.dev.cdp-int.defra.cloud
 
+# Grants config SQS consumer
+GRANTS_CONFIG_QUEUE_URL=http://localhost:4566/000000000000/grants_config_broker_update
+GRANTS_CONFIG_BUCKET=configs-bucket
+SQS_ENDPOINT=http://localhost:4566
+
 # Data Ingest Client IDs and Secrets
 CLIENT_ID_DEV=xxx
 CLIENT_SECRET_DEV=xxx

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   AWS_REGION: eu-west-2
-  AWS_ACCOUNT_ID: "094954420758"
+  AWS_ACCOUNT_ID: '094954420758'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,7 @@ jobs:
         run: chmod +x ./scripts/extract-gz-to-sql
 
       - name: Extract seed files
-        run:
-          ./scripts/extract-gz-to-sql src/land-data/migration changelog/
+        run: ./scripts/extract-gz-to-sql src/land-data/migration changelog/
 
       - name: Publish Database Schema
         uses: DEFRA/cdp-build-action/publish-db-migrations@main

--- a/README.md
+++ b/README.md
@@ -147,6 +147,142 @@ If you would like to run the ingestion process end to end using AWS S3, you can 
 npm run docker:localstack:up
 ```
 
+#### Testing the grants-config-broker SQS integration
+
+Section on how to locally test the end-to-end flow:
+`grants-config-broker` → SNS → SQS → `land-grants-api`
+
+##### Prerequisites
+
+AWS CLI must be installed. Set these env vars once per terminal session to avoid passing credentials on every command:
+
+```bash
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=eu-west-2
+export AWS_ENDPOINT_URL=http://localhost:4566
+```
+
+##### 1. Start the land-grants-api stack
+
+```bash
+# Start postgres and floci (LocalStack emulator) — port 4566 is exposed to the host
+docker compose up floci floci-init land-grants-backend-postgres -d
+
+# Run DB migrations
+npm run docker:migrate:up
+
+# Start the API
+npm run dev
+```
+
+`floci-init` automatically creates the SQS queue (`grants_config_broker_update`), the SNS topic (`gfr__sns___config_update`), and the subscription between them.
+
+##### 2. Prepare the grants-config-broker config directory
+
+The broker reads its release manifest and config files from a `config/` directory relative to its working directory. This directory is git-ignored and must be created manually.
+
+```bash
+cd ../grants-config-broker
+
+# Create the release manifest
+mkdir -p config
+cat > config/release.yml << 'EOF'
+name: land-grants
+version: 0.0.2
+notes: Local test
+environments:
+  - name: dev
+    status: active
+EOF
+
+# Copy action config files from land-grants-config
+mkdir -p "config/land-grants@0.0.2/actions/PA3"
+cp ../land-grants-config/land-grants/actions/PA3/pa3-1.0.0.json \
+   "config/land-grants@0.0.2/actions/PA3/pa3-1.0.0.json"
+```
+
+**Note:**
+The idempotency check will skip versions already present in the DB.
+To exercise the insert path, bump the `semanticVersion` field.
+
+##### 3. Start the grants-config-broker and its mongodb
+
+```bash
+cd ../grants-config-broker
+
+docker compose -f ../grants-config-broker/compose.yml up mongodb -d
+
+PORT=3002 \
+AWS_ENDPOINT_URL=http://localhost:4566 \
+ENVIRONMENT=dev \
+CONFIG_BUCKET_NAME=configs-bucket \
+MONGO_URI=mongodb://127.0.0.1:27017/ \
+SERVICE_VERSION="local-$(date +%s)" \
+npm run dev
+
+```
+
+`SERVICE_VERSION` uses a timestamp so repeated restarts are not blocked by MongoDB's duplicate-key guard (the broker records each deployed version and skips re-runs).
+
+On startup the broker will:
+
+1. Upload config files to `configs-bucket` in LocalStack
+2. Publish an SNS message to `gfr__sns___config_update`
+3. SNS fan-out delivers it to `grants_config_broker_update`
+4. The land-grants-api SQS consumer picks it up, checks if the version exists in the DB, and inserts it if not
+
+##### Useful AWS CLI commands
+
+**List SQS queues:**
+
+```bash
+aws sqs list-queues
+```
+
+**Peek at messages in the queue without consuming them:**
+
+```bash
+aws sqs receive-message \
+  --queue-url http://localhost:4566/000000000000/grants_config_broker_update \
+  --attribute-names All \
+  --message-attribute-names All
+```
+
+**List all files in configs-bucket:**
+
+```bash
+aws s3 ls s3://configs-bucket --recursive
+```
+
+**Inspect a config file directly from S3:**
+
+```bash
+aws s3 cp s3://configs-bucket/land-grants/0.0.3/actions/PA3/pa3-1.0.1.json -
+```
+
+**Manually publish an SNS message** (useful when re-testing without restarting the broker — the broker will not re-deploy a version it has already recorded in MongoDB):
+
+```bash
+aws sns publish \
+  --topic-arn arn:aws:sns:eu-west-2:000000000000:gfr__sns___config_update \
+  --message '["land-grants/0.0.3/actions/PA3/pa3-1.0.1.json","land-grants/0.0.3/metadata.json"]' \
+  --message-attributes '{
+    "grant":   {"DataType":"String","StringValue":"land-grants"},
+    "version": {"DataType":"String","StringValue":"0.0.3"},
+    "status":  {"DataType":"String","StringValue":"active"},
+    "path":    {"DataType":"String","StringValue":"s3://configs-bucket"}
+  }'
+```
+
+**Verify the DB row was inserted or updated:**
+
+```bash
+docker exec -it land-grants-api-land-grants-backend-postgres-1 psql \
+  -U land_grants_api -d land_grants_api \
+  -c "SELECT code, semantic_version, version, is_active FROM actions_config WHERE code = 'PA3' ORDER BY id;"
+```
+
 #### Local data
 
 There is a script to ingest data files for local development: (./scripts/ingest-land-data-local.js)

--- a/compose.migrations.yml
+++ b/compose.migrations.yml
@@ -10,10 +10,9 @@ x-common-postgres: &common-postgres
   POSTGRES_USER: ${POSTGRES_USER:-land_grants_api}
 
 services:
-
   database-up:
     image: liquibase/liquibase:4.31-alpine
-    restart: "no"
+    restart: 'no'
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >
@@ -26,7 +25,7 @@ services:
 
   database-down:
     image: liquibase/liquibase:4.31-alpine
-    restart: "no"
+    restart: 'no'
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >
@@ -41,4 +40,3 @@ networks:
   grants-ui-net:
     name: grants-ui-net
     external: true
-

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -5,7 +5,7 @@ services:
   land-grants-backend-postgres:
     volumes: !reset []
     tmpfs:
-     - /var/lib/postgresql/data
+      - /var/lib/postgresql/data
 
   floci:
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -10,11 +10,10 @@ x-common-postgres: &common-postgres
   POSTGRES_USER: ${POSTGRES_USER:-land_grants_api}
 
 services:
-
   database-up:
     image: liquibase/liquibase:4.31-alpine
     profiles: [migrations]
-    restart: "no"
+    restart: 'no'
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >
@@ -31,7 +30,7 @@ services:
   database-down:
     image: liquibase/liquibase:4.31-alpine
     profiles: [migrations]
-    restart: "no"
+    restart: 'no'
     environment:
       <<: [*common-postgres, *common-migration]
     entrypoint: >
@@ -52,7 +51,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
+      test: ['CMD-SHELL', 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -65,7 +64,7 @@ services:
     build:
       context: .
       target: development
-    command: ["npm", "run", "dev"]
+    command: ['npm', 'run', 'dev']
     environment:
       <<: *common-postgres
       PORT: 3001
@@ -95,7 +94,11 @@ services:
     tmpfs:
       - /app/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -s --connect-timeout 3 http://localhost:4566 > /dev/null 2>&1 || exit 1"]
+      test:
+        [
+          'CMD-SHELL',
+          'curl -s --connect-timeout 3 http://localhost:4566 > /dev/null 2>&1 || exit 1'
+        ]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/compose.yml
+++ b/compose.yml
@@ -70,6 +70,9 @@ services:
       <<: *common-postgres
       PORT: 3001
       POSTGRES_HOST: land-grants-backend-postgres
+      GRANTS_CONFIG_QUEUE_URL: http://floci:4566/000000000000/grants_config_broker_update
+      GRANTS_CONFIG_BUCKET: configs-bucket
+      SQS_ENDPOINT: http://floci:4566
     volumes:
       - ./src:/home/node/src
       - node_deps:/home/node/node_modules
@@ -87,6 +90,8 @@ services:
       FLOCI_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
+    ports:
+      - 4566:4566
     tmpfs:
       - /app/data
     healthcheck:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1054.0",
+        "@aws-sdk/client-sqs": "^3.981.0",
         "@aws-sdk/credential-providers": "^3.1054.0",
         "@aws-sdk/rds-signer": "^3.1054.0",
         "@defra/hapi-tracing": "^1.30.0",
@@ -37,6 +38,7 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "simple-git": "^3.36.0",
+        "sqs-consumer": "^13.0.0",
         "undici": "^8.3.0",
         "unzipper": "^0.12.3"
       },
@@ -299,6 +301,87 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.981.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.981.0.tgz",
+      "integrity": "sha512-wURPt0vup9NE/S2Jdti+Mpe4PlaLFc1CInMCMIEua2/XAbX4MDrMBJ1ZvEKiAvgj/GgptI2gGnmbLHc7w78XrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/credential-provider-node": "^3.972.4",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.5",
+        "@aws-sdk/middleware-user-agent": "^3.972.5",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.981.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.3",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/md5-js": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.981.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.981.0.tgz",
+      "integrity": "sha512-a8nXh/H3/4j+sxhZk+N3acSDlgwTVSZbX9i55dx41gI1H+geuonuRG+Shv3GZsCb46vzc08RK2qC78ypO8uRlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-utf8": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.3.tgz",
+      "integrity": "sha512-c1QpRBn3aMsoqE64dd4Imgjy8Pynfw+eR7GkjElquxUFSnezwYVaOFm8JcYa+Bo/5ssbEyPKcT3+4bmrWYh6eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
@@ -576,6 +659,19 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.15.tgz",
+      "integrity": "sha512-BMvPJcSE+e5Up4eRvIVDOp6Aiwh3ce0z9FJ8LsRBGE9d64j67HLdyqlDaUtzCjmhxDvxw+qIiAElu3+AOzhAnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
@@ -584,6 +680,32 @@
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
         "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.14.tgz",
+      "integrity": "sha512-f/9Rln5bNIoHwPVxSXmW5+8SnteHFwwuoR5Ce+SEis36fKw7pu84G2SpaWRpGqj7zbIAECFVJ+pDiGfQq5r4FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.16.tgz",
+      "integrity": "sha512-AGAe/c6Da/FEjtkR3LViqvaJdxaHQqcVpmf6UMBRQ3e8G2c6EWqjRidMw/FiQzWXUrmfjgXoVcc8QXc4kcuWLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -607,6 +729,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.24.tgz",
+      "integrity": "sha512-ej3vwWFzTP2B0FxlU2JelMaxplEncflFv2ARsoMQ9TXI/yfmsPEZw8zkOdsQp3rMEJ/vN7iKTYDYIcpeMmDRoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
@@ -615,6 +752,19 @@
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
         "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.44.tgz",
+      "integrity": "sha512-K9kryZwhKBsAdk1R6TCMSUDGF2XjMcC89Qm/6o8szdRSodN5MIlo3KzAV4vKyKTkOu/UwoB+Yrj78M+omPZzkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -655,6 +805,19 @@
         "@smithy/core": "^3.24.3",
         "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.18.tgz",
+      "integrity": "sha512-FQLLmG0RHPleDCQAkl10LNH5L+FDOcUKwnRHRhfH0NHhleo46j9u1q0UHlVbKYOBfB0LjQMQgioxrWvLqEZ5Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -716,6 +879,29 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.15.tgz",
+      "integrity": "sha512-8/+GtB/BjIul7uGFXNztIeiQBZbb1eEl/+M8Q+l1qg9uKSGEZf4VtI+9VidrQ3BBE1J1GDkn5W/n+tuHhXSbOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.30.tgz",
+      "integrity": "sha512-W5Pr3Kl9tyH7Pcht2sx90YeO2ennDIwzbBVfQ+bt6MQUNMtf+hPMic8O/IsSWRNn1qTgfuCjTYmB/UD4A75xBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -802,6 +988,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2350,29 +2537,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3094,6 +3258,7 @@
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.9.tgz",
       "integrity": "sha512-YnecZOVx2AD08VvPl0ZaFS0MjEHqg+InGRmBRli731ct+VwI++dpu3BIYA1Z4SMr6HUAnpyvbQ1aq5woe3fBWg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/accept": "^6.0.3",
         "@hapi/ammo": "^6.0.1",
@@ -4212,10 +4377,23 @@
         "@simple-git/args-pathspec": "^1.0.3"
       }
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.5.tgz",
+      "integrity": "sha512-HehAZr4sq2m+4zHgEqDvtWENy/B5yywMKA8Pl4gBcU3F4ekelpZqDLDxQHdJlguaKNyTq31cZYjLWomzdujQrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -4254,6 +4432,136 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.3.5.tgz",
+      "integrity": "sha512-/tUIDaB36qjLq/CIhMRIiFXCT7rVGBGAhFmMA9PbC/iW2u3QPNATZuFSdK0JBO3qeSPoHBeudFMmsbFq2Mf5EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.3.5.tgz",
+      "integrity": "sha512-c8C1GzrU4PcY1QT/HP0ILCTLutyVONT93kPSisOyHoZaXlKQZtV6+RKqolhBtPolGULf59vq2yseagU6+WY82w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.3.5.tgz",
+      "integrity": "sha512-AzWk7NstKv+z3h0GmZlQkDdgcnh3tvBWnBr0zoBY/agV/zaMqEBnpqgF1S+sJAy5yfE1b2KZqiz+uHHV70vOYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.5.tgz",
+      "integrity": "sha512-U/zFWFDuNFspkLAtUbatmpevrRjXwQkoGPJTg1hapUsjLKK+aN3u4seX4+aSBzLom+RnZSdWncfSIgG100vsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.3.5.tgz",
+      "integrity": "sha512-lzOzJ4c0t3vkBut02CjdWNgduN3mUWjc1WK9TPr75KVV6OgVWico9wMDn9ZnQN97VJPYfweBW6Dm5CElvQl8BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.5.tgz",
+      "integrity": "sha512-8DnkSoUMQAcuT/DHdigsFPti8M/Dm6TPCAsrIQ/bUDGxRkrgGuI++3dXRr8CoUyc9r0kGSCcZHjJje407ydgBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.5.tgz",
+      "integrity": "sha512-fumMIfh5xOFjirylbSzmBX9bgQtrWFtQrosPfkjsJSBzqXVbQMNDGIC8oJBz4V3bokIm2F0CL3bziLtbXR7cbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.5.tgz",
+      "integrity": "sha512-+7glfRrb7byruZCPAM53TvmK8cx/ghzAThB4EvPzHynAYobtISl0g+DzzSVEC0NQob5BunP9gC9GP+Fcz6H9yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.3.5.tgz",
+      "integrity": "sha512-Yj4wjBQZXHePRIy9cBIKfCOn/kPjRlgDPGlr7DjIhwrnz8kWu7Ux7UwPr51P/wcug5oq4nWdBXSY4TV5afBdew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.5.tgz",
+      "integrity": "sha512-c2G9QJ4xVZLwAkAf+WQESSSCkKbtt33ytje1klGvTcBn6cKuqV28E+62wbRPHwuTikkB3LQ7CBnNrayCoJur5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
@@ -4262,6 +4570,58 @@
       "dependencies": {
         "@smithy/core": "^3.24.4",
         "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.5.tgz",
+      "integrity": "sha512-QNc22/FgfEm/9/rkefShfQUVckH3HWiQ2RPs+40hwAdY65hbg88gombeHwkfMzmVDZjolcyQeyOjnxZRmpavIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.5.tgz",
+      "integrity": "sha512-jOD+4WNWQLntiLJn3r82C7BLheEbRCKTbU5U5bskZmT7nwRiGkh0IghuHwHRZ1ZEFXpHltQxxp9/koOPsdluJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.3.5.tgz",
+      "integrity": "sha512-e9mjAhxWXj15T2ViqbJxyKI2kVBdNH2RBrtyU9mQXwuhV202PpJsajjMI0lCz4ftv6XW6FtEN5a5aISt3yKj3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.4.5.tgz",
+      "integrity": "sha512-wib00w2YzBzsThNa/0lTs72LuPBQJGuoU4pOsVO7kCid8v5qOkvZJlFIVJKHTQT1wRIqF5qExmDtqYttrcvYzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4282,12 +4642,178 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.5.tgz",
+      "integrity": "sha512-pg9QRQESz3m/5HgAW/z9lA3ln8MSsCWNWc82MX40Djlxpcj/+7DZQ0yIk7tGWYJCVZog/9LBdNl1uEVRAhqm5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/types": {
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
       "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4394,6 +4920,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -4438,6 +4965,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4846,6 +5374,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -5040,6 +5569,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5489,15 +6019,43 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -5756,6 +6314,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6861,6 +7420,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6946,6 +7506,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7096,6 +7657,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -7247,6 +7809,7 @@
       "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
@@ -7403,6 +7966,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -8450,6 +9014,7 @@
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -9560,16 +10125,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -9668,6 +10223,7 @@
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -10422,9 +10978,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -11545,6 +12101,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -11958,6 +12515,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12076,9 +12634,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13196,6 +13754,22 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sqs-consumer": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-13.0.0.tgz",
+      "integrity": "sha512-9wr6rXJym9MSw6s5b83tlul/HxqECgroinR2ZhVGAm3jv+OPzEhQtKwyVkSy8VO+wCYB87A8HDAmP9ZUNHsdLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.876.0",
+        "debug": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.876.0"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -13671,6 +14245,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13782,6 +14357,7 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -13934,6 +14510,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14152,6 +14729,17 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14199,6 +14787,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -14290,6 +14879,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2537,6 +2537,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -13836,16 +13859,6 @@
         "text-decoder": "^1.1.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -13952,6 +13965,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1054.0",
+    "@aws-sdk/client-sqs": "^3.981.0",
     "@aws-sdk/credential-providers": "^3.1054.0",
     "@aws-sdk/rds-signer": "^3.1054.0",
     "@defra/hapi-tracing": "^1.30.0",
@@ -83,6 +84,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "simple-git": "^3.36.0",
+    "sqs-consumer": "^13.0.0",
     "undici": "^8.3.0",
     "unzipper": "^0.12.3"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:server": "NODE_ENV=production babel --delete-dir-on-start --ignore \"**/*.test.js\" --ignore \"**/__fixtures__\" --ignore \"**/test-helpers\" --copy-files --no-copy-ignored --out-dir ./.server ./src",
     "docker:dev": "NODE_ENV=development npm run server:watch",
     "dev": "NODE_ENV=local npm run server:watch",
-    "dev:setup": "npm run setup:husky && npm run extractsql && docker compose up land-grants-backend-postgres -d && npm run docker:migrate:up && npm run dev:ingest",
+    "dev:setup": "npm run setup:husky && npm run extractsql && docker compose up land-grants-backend-postgres floci floci-init -d && npm run docker:migrate:up && npm run dev:ingest",
     "dev:debug": "npm run server:debug",
     "dev:ingest": "NODE_ENV='test' node scripts/local-ingest",
     "docker:migrate:up": "docker compose --profile migrations run --rm database-up",

--- a/scripts/infra/start-floci.sh
+++ b/scripts/infra/start-floci.sh
@@ -14,3 +14,18 @@ done
 echo "Creating S3 bucket"
 aws s3 mb ${INGEST_BUCKET}
 echo "Created S3 bucket: ${INGEST_BUCKET}"
+
+echo "Creating grants-config-broker SQS queue"
+aws sqs create-queue --queue-name grants_config_broker_update
+echo "Created SQS queue: grants_config_broker_update"
+
+echo "Creating grants-config-broker SNS topic"
+aws sns create-topic --name gfr__sns___config_update
+echo "Created SNS topic: gfr__sns___config_update"
+
+echo "Subscribing SQS queue to SNS topic"
+aws sns subscribe \
+  --topic-arn arn:aws:sns:${AWS_REGION}:000000000000:gfr__sns___config_update \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:${AWS_REGION}:000000000000:grants_config_broker_update
+echo "Subscribed grants_config_broker_update to gfr__sns___config_update"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -102,6 +102,34 @@ const config = convict({
       env: 'INGEST_BUCKET'
     }
   },
+  sqs: {
+    region: {
+      doc: 'SQS region',
+      format: String,
+      default: 'eu-west-2',
+      env: 'AWS_REGION'
+    },
+    endpoint: {
+      doc: 'SQS endpoint (LocalStack in local/test environments)',
+      format: String,
+      default: 'http://localhost:4566',
+      env: 'SQS_ENDPOINT'
+    },
+    queueUrl: {
+      doc: 'Grants config broker update SQS queue URL',
+      format: String,
+      default: 'http://localhost:4566/000000000000/grants_config_broker_update',
+      env: 'GRANTS_CONFIG_QUEUE_URL'
+    }
+  },
+  grantsConfig: {
+    s3Bucket: {
+      doc: 'S3 bucket containing grants config files (locally: configs-bucket, remotely: grants-config)',
+      format: String,
+      default: 'configs-bucket',
+      env: 'GRANTS_CONFIG_BUCKET'
+    }
+  },
   ingest: {
     endpoint: {
       doc: 'Ingest endpoint',

--- a/src/features/grants-config/handlers/grants-config-update.handler.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.js
@@ -1,0 +1,62 @@
+import { processActionConfigFile } from '~/src/features/grants-config/service/grants-config.service.js'
+
+/**
+ * Process a single SQS message from the grants_config_broker_update queue.
+ * Handles both SNS-wrapped messages (production) and raw messages (local testing).
+ * @param {import('@aws-sdk/client-sqs').Message} message - SQS message
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ * @param {import('~/src/features/common/postgres.d.js').Pool} db
+ * @param {import('~/src/features/common/logger.d.js').Logger} logger
+ * @param {{ grantsConfigBucket: string }} options
+ * @returns {Promise<void>}
+ */
+async function processMessage(message, s3Client, db, logger, options) {
+  const { grantsConfigBucket } = options
+
+  if (!message.Body) {
+    throw new Error(`SQS message ${message.MessageId} has no body`)
+  }
+
+  const body = JSON.parse(message.Body)
+
+  let manifest
+  let status
+  let grant
+
+  if (body.Type === 'Notification' && body.Message) {
+    manifest = JSON.parse(body.Message)
+    status = body.MessageAttributes?.status?.Value
+    grant = body.MessageAttributes?.grant?.Value
+  } else {
+    manifest = body.manifest ?? []
+    status = body.status
+    grant = body.grant
+  }
+
+  if (grant !== 'land-grants') {
+    logger.info(
+      `Skipping grants-config message for grant="${grant}" (only "land-grants" is processed)`
+    )
+    return
+  }
+
+  if (status !== 'active') {
+    logger.info(
+      `Skipping grants-config message with status="${status}" (only "active" is processed)`
+    )
+    return
+  }
+
+  const actionKeys = manifest.filter((key) => key.includes('/actions/'))
+
+  if (actionKeys.length === 0) {
+    logger.info('No action config files found in manifest — nothing to process')
+    return
+  }
+
+  for (const key of actionKeys) {
+    await processActionConfigFile(logger, s3Client, db, key, grantsConfigBucket)
+  }
+}
+
+export { processMessage }

--- a/src/features/grants-config/handlers/grants-config-update.handler.test.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.test.js
@@ -1,0 +1,258 @@
+import { processMessage } from './grants-config-update.handler.js'
+
+import { processActionConfigFile } from '~/src/features/grants-config/service/grants-config.service.js'
+
+vi.mock('~/src/features/grants-config/service/grants-config.service.js')
+
+/**
+ * Builds an SNS-wrapped SQS message body matching the shape produced by
+ * grants-config-broker's publishMessage(manifest, { grant, path, version, status }).
+ */
+function buildSnsMessage({
+  grant = 'land-grants',
+  version = '0.0.2',
+  status = 'active',
+  path = 's3://grants-config',
+  manifest = [
+    'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
+    'land-grants/0.0.2/metadata.json'
+  ]
+} = {}) {
+  return {
+    MessageId: 'msg-1',
+    Body: JSON.stringify({
+      Type: 'Notification',
+      Message: JSON.stringify(manifest),
+      MessageAttributes: {
+        grant: { Type: 'String', Value: grant },
+        version: { Type: 'String', Value: version },
+        status: { Type: 'String', Value: status },
+        path: { Type: 'String', Value: path }
+      }
+    })
+  }
+}
+
+describe('processMessage', () => {
+  let mockLogger
+  let mockS3Client
+  let mockDb
+  const options = { grantsConfigBucket: 'configs-bucket' }
+
+  beforeEach(() => {
+    mockLogger = { info: vi.fn(), error: vi.fn() }
+    mockS3Client = {}
+    mockDb = {}
+    processActionConfigFile.mockResolvedValue(undefined)
+  })
+
+  describe('grant filtering', () => {
+    test('processes a message for grant "land-grants"', async () => {
+      await processMessage(
+        buildSnsMessage(),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).toHaveBeenCalledTimes(1)
+    })
+
+    test('skips a message for a different grant', async () => {
+      await processMessage(
+        buildSnsMessage({ grant: 'example-grant-with-auth', status: 'active' }),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('grant="example-grant-with-auth"')
+      )
+    })
+
+    test('skips a message when grant attribute is absent', async () => {
+      const noGrantMessage = {
+        MessageId: 'msg-no-grant',
+        Body: JSON.stringify({
+          Type: 'Notification',
+          Message: JSON.stringify([
+            'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'
+          ]),
+          MessageAttributes: {
+            status: { Type: 'String', Value: 'active' }
+          }
+        })
+      }
+
+      await processMessage(
+        noGrantMessage,
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('grant="undefined"')
+      )
+    })
+  })
+
+  describe('status filtering', () => {
+    test('processes a message with status "active"', async () => {
+      await processMessage(
+        buildSnsMessage({ status: 'active' }),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).toHaveBeenCalledTimes(1)
+    })
+
+    test('skips a message with status "draft"', async () => {
+      await processMessage(
+        buildSnsMessage({ status: 'draft' }),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('status="draft"')
+      )
+    })
+
+    test('skips a message with status "none"', async () => {
+      await processMessage(
+        buildSnsMessage({ status: 'none' }),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('manifest processing', () => {
+    test('processes only action config files from the manifest', async () => {
+      await processMessage(
+        buildSnsMessage(),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).toHaveBeenCalledTimes(1)
+      expect(processActionConfigFile).toHaveBeenCalledWith(
+        mockLogger,
+        mockS3Client,
+        mockDb,
+        'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
+        'configs-bucket'
+      )
+    })
+
+    test('skips non-action files in the manifest', async () => {
+      await processMessage(
+        buildSnsMessage(),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      const calledKeys = processActionConfigFile.mock.calls.map((c) => c[3])
+      expect(calledKeys).not.toContain('land-grants/0.0.2/metadata.json')
+    })
+
+    test('processes multiple action files in the manifest', async () => {
+      const message = buildSnsMessage({
+        manifest: [
+          'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
+          'land-grants/0.0.2/actions/CSAM3/csam3-1.0.0.json',
+          'land-grants/0.0.2/metadata.json'
+        ]
+      })
+
+      await processMessage(message, mockS3Client, mockDb, mockLogger, options)
+
+      expect(processActionConfigFile).toHaveBeenCalledTimes(2)
+    })
+
+    test('does nothing when the manifest has no action files', async () => {
+      const message = buildSnsMessage({
+        manifest: ['land-grants/0.0.2/metadata.json']
+      })
+
+      await processMessage(message, mockS3Client, mockDb, mockLogger, options)
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No action config files found')
+      )
+    })
+  })
+
+  describe('raw messages (local testing)', () => {
+    test('processes a raw message with grant, manifest and status fields', async () => {
+      const rawMessage = {
+        MessageId: 'msg-raw',
+        Body: JSON.stringify({
+          grant: 'land-grants',
+          manifest: ['land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'],
+          status: 'active'
+        })
+      }
+
+      await processMessage(
+        rawMessage,
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).toHaveBeenCalledTimes(1)
+      expect(processActionConfigFile).toHaveBeenCalledWith(
+        mockLogger,
+        mockS3Client,
+        mockDb,
+        'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
+        'configs-bucket'
+      )
+    })
+
+    test('skips a raw message for a different grant', async () => {
+      const rawMessage = {
+        MessageId: 'msg-raw-other',
+        Body: JSON.stringify({
+          grant: 'example-grant-with-auth',
+          manifest: ['example-grant-with-auth/0.0.1/grants-ui/file1.txt'],
+          status: 'active'
+        })
+      }
+
+      await processMessage(
+        rawMessage,
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
+
+      expect(processActionConfigFile).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/grants-config/index.js
+++ b/src/features/grants-config/index.js
@@ -1,0 +1,1 @@
+export { grantsConfigSqsPlugin as grantsConfigConsumer } from '~/src/features/grants-config/sqs/sqs-client.js'

--- a/src/features/grants-config/queries/getActionConfigByVersion.query.js
+++ b/src/features/grants-config/queries/getActionConfigByVersion.query.js
@@ -1,0 +1,33 @@
+import { logDatabaseError } from '~/src/features/common/helpers/logging/log-helpers.js'
+
+/**
+ * Check whether an action config already exists at the given semantic version.
+ * @param {import('~/src/features/common/logger.d.js').Logger} logger
+ * @param {import('~/src/features/common/postgres.d.js').Pool} db
+ * @param {string} code - Action code, e.g. 'PA3'
+ * @param {string} semanticVersion - e.g. '1.0.0'
+ * @returns {Promise<boolean>} true if the version already exists
+ */
+async function getActionConfigByVersion(logger, db, code, semanticVersion) {
+  let client
+  try {
+    client = await db.connect()
+    const result = await client.query(
+      'SELECT id FROM actions_config WHERE code = $1 AND semantic_version = $2 LIMIT 1',
+      [code, semanticVersion]
+    )
+    return result.rows.length > 0
+  } catch (error) {
+    logDatabaseError(logger, {
+      operation: 'Get action config by version',
+      error
+    })
+    return false
+  } finally {
+    if (client) {
+      client.release()
+    }
+  }
+}
+
+export { getActionConfigByVersion }

--- a/src/features/grants-config/queries/getActionConfigByVersion.query.test.js
+++ b/src/features/grants-config/queries/getActionConfigByVersion.query.test.js
@@ -1,0 +1,108 @@
+import { getActionConfigByVersion } from './getActionConfigByVersion.query.js'
+
+describe('getActionConfigByVersion', () => {
+  let mockDb
+  let mockLogger
+  let mockClient
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn()
+    }
+    mockDb = {
+      connect: vi.fn().mockResolvedValue(mockClient)
+    }
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn()
+    }
+  })
+
+  test('returns true when a matching row exists', async () => {
+    mockClient.query.mockResolvedValue({ rows: [{ id: 1 }] })
+
+    const result = await getActionConfigByVersion(
+      mockLogger,
+      mockDb,
+      'PA3',
+      '1.0.0'
+    )
+
+    expect(result).toBe(true)
+  })
+
+  test('returns false when no matching row exists', async () => {
+    mockClient.query.mockResolvedValue({ rows: [] })
+
+    const result = await getActionConfigByVersion(
+      mockLogger,
+      mockDb,
+      'PA3',
+      '1.0.0'
+    )
+
+    expect(result).toBe(false)
+  })
+
+  test('queries with the correct SQL and parameters', async () => {
+    mockClient.query.mockResolvedValue({ rows: [] })
+
+    await getActionConfigByVersion(mockLogger, mockDb, 'PA3', '1.0.0')
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'SELECT id FROM actions_config WHERE code = $1 AND semantic_version = $2 LIMIT 1',
+      ['PA3', '1.0.0']
+    )
+  })
+
+  test('releases the client after a successful query', async () => {
+    mockClient.query.mockResolvedValue({ rows: [] })
+
+    await getActionConfigByVersion(mockLogger, mockDb, 'PA3', '1.0.0')
+
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+  })
+
+  test('releases the client after a query error', async () => {
+    mockClient.query.mockRejectedValue(new Error('DB error'))
+
+    await getActionConfigByVersion(mockLogger, mockDb, 'PA3', '1.0.0')
+
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns false and logs error on query failure', async () => {
+    const error = new Error('Connection lost')
+    mockClient.query.mockRejectedValue(error)
+
+    const result = await getActionConfigByVersion(
+      mockLogger,
+      mockDb,
+      'PA3',
+      '1.0.0'
+    )
+
+    expect(result).toBe(false)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'Connection lost' })
+      }),
+      expect.stringContaining('Database operation failed')
+    )
+  })
+
+  test('returns false and does not release client on connection error', async () => {
+    mockDb.connect.mockRejectedValue(new Error('Cannot connect'))
+
+    const result = await getActionConfigByVersion(
+      mockLogger,
+      mockDb,
+      'PA3',
+      '1.0.0'
+    )
+
+    expect(result).toBe(false)
+    expect(mockClient.release).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/grants-config/queries/insertActionConfig.query.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.js
@@ -1,0 +1,53 @@
+import { logDatabaseError } from '~/src/features/common/helpers/logging/log-helpers.js'
+
+/**
+ * Insert a new action config version into the DB.
+ * Wraps in a transaction: deactivates the existing active row first,
+ * then inserts the new row with is_active=TRUE.
+ * @param {import('~/src/features/common/logger.d.js').Logger} logger
+ * @param {import('~/src/features/common/postgres.d.js').Pool} db
+ * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number }} params
+ * @returns {Promise<boolean>} true on success
+ */
+async function insertActionConfig(logger, db, params) {
+  const { code, config, major, minor, patch, displayOrder } = params
+  let client
+  try {
+    client = await db.connect()
+    await client.query('BEGIN')
+
+    await client.query(
+      'UPDATE actions_config SET is_active = FALSE WHERE code = $1 AND is_active = TRUE',
+      [code]
+    )
+
+    await client.query(
+      `INSERT INTO actions_config
+         (code, version, config, is_active, last_updated_at, major_version, minor_version, patch_version, display_order)
+       VALUES (
+         $1,
+         (SELECT CAST(COALESCE(MAX(version::integer), 0) + 1 AS text) FROM actions_config WHERE code = $1),
+         $2, TRUE, NOW(), $3, $4, $5, $6
+       )`,
+      [code, JSON.stringify(config), major, minor, patch, displayOrder]
+    )
+
+    await client.query('COMMIT')
+    return true
+  } catch (error) {
+    if (client) {
+      await client.query('ROLLBACK').catch(() => undefined)
+    }
+    logDatabaseError(logger, {
+      operation: 'Insert action config',
+      error
+    })
+    return false
+  } finally {
+    if (client) {
+      client.release()
+    }
+  }
+}
+
+export { insertActionConfig }

--- a/src/features/grants-config/queries/insertActionConfig.query.test.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.test.js
@@ -1,0 +1,120 @@
+import { insertActionConfig } from './insertActionConfig.query.js'
+
+describe('insertActionConfig', () => {
+  let mockDb
+  let mockLogger
+  let mockClient
+
+  const params = {
+    code: 'PA3',
+    config: { start_date: '2025-01-01', rules: [] },
+    major: 1,
+    minor: 0,
+    patch: 0,
+    displayOrder: 0
+  }
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn()
+    }
+    mockDb = {
+      connect: vi.fn().mockResolvedValue(mockClient)
+    }
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn()
+    }
+  })
+
+  test('executes BEGIN, UPDATE, INSERT and COMMIT in order', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    const calls = mockClient.query.mock.calls.map((c) =>
+      typeof c[0] === 'string' ? c[0].trim() : c[0]
+    )
+    expect(calls[0]).toBe('BEGIN')
+    expect(calls[1]).toContain('UPDATE actions_config SET is_active = FALSE')
+    expect(calls[2]).toContain('INSERT INTO actions_config')
+    expect(calls[3]).toBe('COMMIT')
+  })
+
+  test('deactivates existing active config for the same code', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'UPDATE actions_config SET is_active = FALSE WHERE code = $1 AND is_active = TRUE',
+      ['PA3']
+    )
+  })
+
+  test('inserts with correct parameters', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    const insertCall = mockClient.query.mock.calls.find(
+      (c) =>
+        typeof c[0] === 'string' && c[0].includes('INSERT INTO actions_config')
+    )
+    expect(insertCall).toBeDefined()
+    const [, insertParams] = insertCall
+    expect(insertParams[0]).toBe('PA3')
+    expect(insertParams[1]).toBe(JSON.stringify(params.config))
+    expect(insertParams[2]).toBe(1) // major
+    expect(insertParams[3]).toBe(0) // minor
+    expect(insertParams[4]).toBe(0) // patch
+    expect(insertParams[5]).toBe(0) // displayOrder
+  })
+
+  test('returns true on success', async () => {
+    const result = await insertActionConfig(mockLogger, mockDb, params)
+    expect(result).toBe(true)
+  })
+
+  test('releases the client after success', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+  })
+
+  test('rolls back and returns false on INSERT error', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE
+      .mockRejectedValueOnce(new Error('Insert failed'))
+
+    const result = await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(result).toBe(false)
+    const rollbackCall = mockClient.query.mock.calls.find(
+      (c) => c[0] === 'ROLLBACK'
+    )
+    expect(rollbackCall).toBeDefined()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'Insert failed' })
+      }),
+      expect.stringContaining('Database operation failed')
+    )
+  })
+
+  test('releases the client after an error', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({}) // ROLLBACK
+
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns false and does not release client on connection error', async () => {
+    mockDb.connect.mockRejectedValue(new Error('Cannot connect'))
+
+    const result = await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(result).toBe(false)
+    expect(mockClient.release).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/grants-config/schema/action-config.schema.js
+++ b/src/features/grants-config/schema/action-config.schema.js
@@ -1,0 +1,14 @@
+import Joi from 'joi'
+
+export const actionConfigInputSchema = Joi.object({
+  code: Joi.string().required(),
+  semanticVersion: Joi.string().required(),
+  displayOrder: Joi.number().optional(),
+  startDate: Joi.string().isoDate().optional(),
+  applicationUnitOfMeasurement: Joi.string().optional(),
+  durationYears: Joi.number().optional(),
+  payment: Joi.object().allow(null).optional(),
+  paymentMethod: Joi.object().optional(),
+  landCoverClassCodes: Joi.array().items(Joi.string()).optional(),
+  rules: Joi.array().items(Joi.object()).optional()
+}).options({ allowUnknown: true })

--- a/src/features/grants-config/service/grants-config.service.js
+++ b/src/features/grants-config/service/grants-config.service.js
@@ -21,6 +21,12 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
   const { code, semanticVersion, major, minor, patch, displayOrder, config } =
     transformActionConfig(json)
 
+  if (!semanticVersion) {
+    throw new Error(
+      `Action config file is missing a valid semanticVersion: ${s3Key}`
+    )
+  }
+
   const exists = await getActionConfigByVersion(
     logger,
     db,

--- a/src/features/grants-config/service/grants-config.service.js
+++ b/src/features/grants-config/service/grants-config.service.js
@@ -1,0 +1,62 @@
+import { getFile } from '~/src/features/common/s3/s3.js'
+import { getActionConfigByVersion } from '~/src/features/grants-config/queries/getActionConfigByVersion.query.js'
+import { insertActionConfig } from '~/src/features/grants-config/queries/insertActionConfig.query.js'
+import { transformActionConfig } from '~/src/features/grants-config/transforms/action-config.transform.js'
+
+/**
+ * Check if the action config version already exists in the DB; if not, download from S3 and insert.
+ * @param {import('~/src/features/common/logger.d.js').Logger} logger
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ * @param {import('~/src/features/common/postgres.d.js').Pool} db
+ * @param {string} s3Key - S3 object key, e.g. 'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'
+ * @param {string} bucket - S3 bucket name
+ * @returns {Promise<void>}
+ */
+async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
+  logger.info(`Processing action config file: ${s3Key}`)
+
+  const response = await getFile(s3Client, bucket, s3Key)
+  const json = JSON.parse(await response.Body.transformToString())
+
+  const { code, semanticVersion, major, minor, patch, displayOrder, config } =
+    transformActionConfig(json)
+
+  const exists = await getActionConfigByVersion(
+    logger,
+    db,
+    code,
+    semanticVersion
+  )
+
+  if (exists) {
+    logger.info(
+      `Action config already exists: code=${code} semanticVersion=${semanticVersion} — skipping`
+    )
+    return
+  }
+
+  logger.info(
+    `Inserting new action config: code=${code} semanticVersion=${semanticVersion}`
+  )
+
+  const inserted = await insertActionConfig(logger, db, {
+    code,
+    config,
+    major,
+    minor,
+    patch,
+    displayOrder
+  })
+
+  if (!inserted) {
+    throw new Error(
+      `Failed to insert action config: code=${code} semanticVersion=${semanticVersion}`
+    )
+  }
+
+  logger.info(
+    `Successfully inserted action config: code=${code} semanticVersion=${semanticVersion}`
+  )
+}
+
+export { processActionConfigFile }

--- a/src/features/grants-config/service/grants-config.service.test.js
+++ b/src/features/grants-config/service/grants-config.service.test.js
@@ -1,0 +1,157 @@
+import { processActionConfigFile } from './grants-config.service.js'
+
+import { getFile } from '~/src/features/common/s3/s3.js'
+import { getActionConfigByVersion } from '~/src/features/grants-config/queries/getActionConfigByVersion.query.js'
+import { insertActionConfig } from '~/src/features/grants-config/queries/insertActionConfig.query.js'
+import { transformActionConfig } from '~/src/features/grants-config/transforms/action-config.transform.js'
+
+vi.mock('~/src/features/common/s3/s3.js')
+vi.mock(
+  '~/src/features/grants-config/queries/getActionConfigByVersion.query.js'
+)
+vi.mock('~/src/features/grants-config/queries/insertActionConfig.query.js')
+vi.mock('~/src/features/grants-config/transforms/action-config.transform.js')
+
+describe('processActionConfigFile', () => {
+  let mockLogger
+  let mockS3Client
+  let mockDb
+  const s3Key = 'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'
+  const bucket = 'configs-bucket'
+
+  const transformedConfig = {
+    code: 'PA3',
+    semanticVersion: '1.0.0',
+    major: 1,
+    minor: 0,
+    patch: 0,
+    displayOrder: 0,
+    config: { start_date: '2025-01-01', rules: [] }
+  }
+
+  beforeEach(() => {
+    mockLogger = { info: vi.fn(), error: vi.fn() }
+    mockS3Client = {}
+    mockDb = {}
+
+    getFile.mockResolvedValue({
+      Body: {
+        transformToString: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify({ code: 'PA3' }))
+      }
+    })
+    transformActionConfig.mockReturnValue(transformedConfig)
+    getActionConfigByVersion.mockResolvedValue(false)
+    insertActionConfig.mockResolvedValue(true)
+  })
+
+  test('fetches the file from S3 with the correct key and bucket', async () => {
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(getFile).toHaveBeenCalledWith(mockS3Client, bucket, s3Key)
+  })
+
+  test('transforms the parsed JSON', async () => {
+    const jsonContent = { code: 'PA3', semanticVersion: '1.0.0' }
+    getFile.mockResolvedValue({
+      Body: {
+        transformToString: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify(jsonContent))
+      }
+    })
+
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(transformActionConfig).toHaveBeenCalledWith(jsonContent)
+  })
+
+  test('checks the DB for an existing version', async () => {
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(getActionConfigByVersion).toHaveBeenCalledWith(
+      mockLogger,
+      mockDb,
+      'PA3',
+      '1.0.0'
+    )
+  })
+
+  test('skips insertion when the version already exists', async () => {
+    getActionConfigByVersion.mockResolvedValue(true)
+
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(insertActionConfig).not.toHaveBeenCalled()
+  })
+
+  test('inserts the config when the version does not exist', async () => {
+    getActionConfigByVersion.mockResolvedValue(false)
+
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(insertActionConfig).toHaveBeenCalledWith(mockLogger, mockDb, {
+      code: 'PA3',
+      config: transformedConfig.config,
+      major: 1,
+      minor: 0,
+      patch: 0,
+      displayOrder: 0
+    })
+  })
+
+  test('logs info when skipping an existing version', async () => {
+    getActionConfigByVersion.mockResolvedValue(true)
+
+    await processActionConfigFile(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      s3Key,
+      bucket
+    )
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('already exists')
+    )
+  })
+
+  test('propagates S3 errors', async () => {
+    getFile.mockRejectedValue(new Error('S3 unavailable'))
+
+    await expect(
+      processActionConfigFile(mockLogger, mockS3Client, mockDb, s3Key, bucket)
+    ).rejects.toThrow('S3 unavailable')
+  })
+})

--- a/src/features/grants-config/service/grants-config.service.test.js
+++ b/src/features/grants-config/service/grants-config.service.test.js
@@ -154,4 +154,15 @@ describe('processActionConfigFile', () => {
       processActionConfigFile(mockLogger, mockS3Client, mockDb, s3Key, bucket)
     ).rejects.toThrow('S3 unavailable')
   })
+
+  test('throws with the s3Key when transform returns a falsy semanticVersion', async () => {
+    transformActionConfig.mockReturnValueOnce({
+      ...transformedConfig,
+      semanticVersion: undefined
+    })
+
+    await expect(
+      processActionConfigFile(mockLogger, mockS3Client, mockDb, s3Key, bucket)
+    ).rejects.toThrow(s3Key)
+  })
 })

--- a/src/features/grants-config/sqs/sqs-client.js
+++ b/src/features/grants-config/sqs/sqs-client.js
@@ -1,0 +1,82 @@
+import { SQSClient } from '@aws-sdk/client-sqs'
+import { Consumer } from 'sqs-consumer'
+import { config } from '~/src/config/index.js'
+import { processMessage } from '~/src/features/grants-config/handlers/grants-config-update.handler.js'
+
+export const grantsConfigSqsPlugin = {
+  plugin: {
+    name: 'grantsConfigSqs',
+    version: '1.0.0',
+    register(server, options) {
+      server.logger.info('Setting up grants-config-broker SQS consumer')
+
+      const sqsClient = new SQSClient({
+        region: options.sqsRegion,
+        endpoint: options.sqsEndpoint
+      })
+
+      const app = Consumer.create({
+        queueUrl: options.queueUrl,
+        handleMessage: async (message) => {
+          try {
+            await processMessage(
+              message,
+              server.s3,
+              server.postgresDb,
+              server.logger,
+              {
+                grantsConfigBucket: options.grantsConfigBucket
+              }
+            )
+            server.logger.info(
+              `Successfully processed grants-config-broker message: ${message.MessageId}`
+            )
+          } catch (err) {
+            server.logger.error(
+              err,
+              'Failed to process grants-config-broker message'
+            )
+            throw err
+          }
+        },
+        sqs: sqsClient,
+        batchSize: 1,
+        waitTimeSeconds: 20,
+        visibilityTimeout: 30,
+        handleMessageTimeout: 30000,
+        attributeNames: ['All'],
+        messageAttributeNames: ['All']
+      })
+
+      app.on('error', (err) => {
+        server.logger.error(err, 'grants-config-broker SQS Consumer error')
+      })
+
+      app.on('processing_error', (err) => {
+        server.logger.error(
+          err,
+          'grants-config-broker SQS message processing error'
+        )
+      })
+
+      app.on('started', () => {
+        server.logger.info('grants-config-broker SQS Consumer started')
+      })
+
+      app.start()
+
+      server.events.on('stop', () => {
+        server.logger.info('Stopping grants-config-broker SQS consumer')
+        app.stop()
+        server.logger.info('Closing grants-config-broker SQS client')
+        sqsClient.destroy()
+      })
+    }
+  },
+  options: {
+    sqsRegion: config.get('sqs.region'),
+    sqsEndpoint: config.get('sqs.endpoint'),
+    queueUrl: config.get('sqs.queueUrl'),
+    grantsConfigBucket: config.get('grantsConfig.s3Bucket')
+  }
+}

--- a/src/features/grants-config/sqs/sqs-client.test.js
+++ b/src/features/grants-config/sqs/sqs-client.test.js
@@ -1,0 +1,229 @@
+import { vi } from 'vitest'
+import { Consumer } from 'sqs-consumer'
+import { grantsConfigSqsPlugin } from './sqs-client.js'
+
+const mockSqsClientInstance = {
+  send: vi.fn(),
+  destroy: vi.fn()
+}
+
+vi.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: class MockSQSClient {
+    constructor() {
+      return mockSqsClientInstance
+    }
+  }
+}))
+
+vi.mock('sqs-consumer')
+
+vi.mock('~/src/config/index.js', () => ({
+  config: {
+    get: vi.fn((key) => {
+      switch (key) {
+        case 'sqs.region':
+          return 'eu-west-2'
+        case 'sqs.endpoint':
+          return 'http://localhost:4566'
+        case 'sqs.queueUrl':
+          return 'http://localhost:4566/000000000000/grants_config_broker_update'
+        case 'grantsConfig.s3Bucket':
+          return 'configs-bucket'
+        default:
+          return undefined
+      }
+    })
+  }
+}))
+
+vi.mock(
+  '~/src/features/grants-config/handlers/grants-config-update.handler.js',
+  () => ({
+    processMessage: vi.fn()
+  })
+)
+
+describe('grantsConfigSqsPlugin', () => {
+  let server
+  let mockConsumer
+  let mockLogger
+
+  const options = {
+    sqsRegion: 'eu-west-2',
+    sqsEndpoint: 'http://localhost:4566',
+    queueUrl: 'http://localhost:4566/000000000000/grants_config_broker_update',
+    grantsConfigBucket: 'configs-bucket'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLogger = { info: vi.fn(), error: vi.fn() }
+
+    server = {
+      logger: mockLogger,
+      s3: {},
+      postgresDb: {},
+      events: { on: vi.fn() }
+    }
+
+    mockConsumer = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      on: vi.fn()
+    }
+
+    Consumer.create = vi.fn().mockReturnValue(mockConsumer)
+  })
+
+  test('creates a Consumer with the correct options', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    expect(Consumer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueUrl: options.queueUrl,
+        handleMessage: expect.any(Function),
+        sqs: mockSqsClientInstance,
+        batchSize: 1,
+        waitTimeSeconds: 20,
+        visibilityTimeout: 30,
+        handleMessageTimeout: 30000,
+        attributeNames: ['All'],
+        messageAttributeNames: ['All']
+      })
+    )
+  })
+
+  test('starts the consumer on registration', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    expect(mockConsumer.start).toHaveBeenCalled()
+  })
+
+  test('registers error, processing_error, and started event handlers', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    const eventNames = mockConsumer.on.mock.calls.map((c) => c[0])
+    expect(eventNames).toContain('error')
+    expect(eventNames).toContain('processing_error')
+    expect(eventNames).toContain('started')
+  })
+
+  test('logs on consumer start event', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    const startedHandler = mockConsumer.on.mock.calls.find(
+      (c) => c[0] === 'started'
+    )[1]
+    startedHandler()
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('SQS Consumer started')
+    )
+  })
+
+  test('logs consumer errors', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    const errorHandler = mockConsumer.on.mock.calls.find(
+      (c) => c[0] === 'error'
+    )[1]
+    const error = new Error('Consumer error')
+    errorHandler(error)
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      error,
+      expect.stringContaining('Consumer error')
+    )
+  })
+
+  test('stops the consumer and destroys the SQS client on server stop', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    const stopHandler = server.events.on.mock.calls.find(
+      (c) => c[0] === 'stop'
+    )[1]
+    stopHandler()
+
+    expect(mockConsumer.stop).toHaveBeenCalled()
+    expect(mockSqsClientInstance.destroy).toHaveBeenCalled()
+  })
+
+  describe('handleMessage', () => {
+    let handleMessage
+
+    beforeEach(() => {
+      grantsConfigSqsPlugin.plugin.register(server, options)
+      handleMessage = Consumer.create.mock.calls[0][0].handleMessage
+    })
+
+    test('calls processMessage with the correct arguments', async () => {
+      const { processMessage } =
+        await import('~/src/features/grants-config/handlers/grants-config-update.handler.js')
+      const message = { MessageId: 'msg-1', Body: '{}' }
+
+      await handleMessage(message)
+
+      expect(processMessage).toHaveBeenCalledWith(
+        message,
+        server.s3,
+        server.postgresDb,
+        server.logger,
+        { grantsConfigBucket: options.grantsConfigBucket }
+      )
+    })
+
+    test('logs success after processMessage resolves', async () => {
+      const message = { MessageId: 'msg-1', Body: '{}' }
+
+      await handleMessage(message)
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('msg-1')
+      )
+    })
+
+    test('logs error and rethrows when processMessage throws', async () => {
+      const { processMessage } =
+        await import('~/src/features/grants-config/handlers/grants-config-update.handler.js')
+      const error = new Error('processing failed')
+      processMessage.mockRejectedValueOnce(error)
+      const message = { MessageId: 'msg-err', Body: '{}' }
+
+      await expect(handleMessage(message)).rejects.toThrow('processing failed')
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        error,
+        expect.stringContaining('Failed to process')
+      )
+    })
+  })
+
+  test('logs processing_error events', () => {
+    grantsConfigSqsPlugin.plugin.register(server, options)
+
+    const handler = mockConsumer.on.mock.calls.find(
+      (c) => c[0] === 'processing_error'
+    )[1]
+    const error = new Error('processing error')
+    handler(error)
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      error,
+      expect.stringContaining('processing error')
+    )
+  })
+
+  test('plugin options derive values from config', () => {
+    expect(grantsConfigSqsPlugin.options.sqsRegion).toBe('eu-west-2')
+    expect(grantsConfigSqsPlugin.options.sqsEndpoint).toBe(
+      'http://localhost:4566'
+    )
+    expect(grantsConfigSqsPlugin.options.queueUrl).toBe(
+      'http://localhost:4566/000000000000/grants_config_broker_update'
+    )
+    expect(grantsConfigSqsPlugin.options.grantsConfigBucket).toBe(
+      'configs-bucket'
+    )
+  })
+})

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -21,7 +21,7 @@ export function transformActionConfig(actionJson) {
 
   return {
     code: actionJson.code,
-    semanticVersion: actionJson.semanticVersion,
+    semanticVersion: `${major}.${minor}.${patch}`,
     major,
     minor,
     patch,
@@ -35,10 +35,24 @@ export function transformActionConfig(actionJson) {
  * @returns {{ major: number, minor: number, patch: number }}
  */
 function parseSemanticVersion(semanticVersion) {
-  const parts = (semanticVersion ?? '').split('.')
-  return {
-    major: Number.parseInt(parts[0] || '1', 10),
-    minor: Number.parseInt(parts[1] || '0', 10),
-    patch: Number.parseInt(parts[2] || '0', 10)
+  if (!semanticVersion) {
+    throw new Error('semanticVersion is required')
   }
+
+  const parts = semanticVersion.split('.')
+  const major = Number.parseInt(parts[0] || '0', 10)
+  const minor = Number.parseInt(parts[1] || '0', 10)
+  const patch = Number.parseInt(parts[2] || '0', 10)
+
+  if (
+    !Number.isFinite(major) ||
+    !Number.isFinite(minor) ||
+    !Number.isFinite(patch)
+  ) {
+    throw new Error(
+      `Invalid semanticVersion "${semanticVersion}": all parts must be integers`
+    )
+  }
+
+  return { major, minor, patch }
 }

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -1,3 +1,5 @@
+import { actionConfigInputSchema } from '../schema/action-config.schema.js'
+
 /**
  * Transform an action config JSON (camelCase from land-grants-config repo)
  * into the shape stored in the actions_config DB table.
@@ -5,6 +7,13 @@
  * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, config: object }}
  */
 export function transformActionConfig(actionJson) {
+  const { error } = actionConfigInputSchema.validate(actionJson)
+  if (error) {
+    throw new TypeError(
+      `Invalid action config: ${error.details.map((d) => d.message).join('; ')}`
+    )
+  }
+
   const { major, minor, patch } = parseSemanticVersion(
     actionJson.semanticVersion
   )
@@ -35,10 +44,6 @@ export function transformActionConfig(actionJson) {
  * @returns {{ major: number, minor: number, patch: number }}
  */
 function parseSemanticVersion(semanticVersion) {
-  if (!semanticVersion) {
-    throw new Error('semanticVersion is required')
-  }
-
   const parts = semanticVersion.split('.')
   const major = Number.parseInt(parts[0] || '0', 10)
   const minor = Number.parseInt(parts[1] || '0', 10)
@@ -49,7 +54,7 @@ function parseSemanticVersion(semanticVersion) {
     !Number.isFinite(minor) ||
     !Number.isFinite(patch)
   ) {
-    throw new Error(
+    throw new TypeError(
       `Invalid semanticVersion "${semanticVersion}": all parts must be integers`
     )
   }

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -1,0 +1,44 @@
+/**
+ * Transform an action config JSON (camelCase from land-grants-config repo)
+ * into the shape stored in the actions_config DB table.
+ * @param {object} actionJson - Raw action JSON from S3
+ * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, config: object }}
+ */
+export function transformActionConfig(actionJson) {
+  const { major, minor, patch } = parseSemanticVersion(
+    actionJson.semanticVersion
+  )
+
+  const config = {
+    start_date: actionJson.startDate,
+    application_unit_of_measurement: actionJson.applicationUnitOfMeasurement,
+    duration_years: actionJson.durationYears,
+    payment: actionJson.payment,
+    payment_method: actionJson.paymentMethod,
+    land_cover_class_codes: actionJson.landCoverClassCodes ?? [],
+    rules: actionJson.rules ?? []
+  }
+
+  return {
+    code: actionJson.code,
+    semanticVersion: actionJson.semanticVersion,
+    major,
+    minor,
+    patch,
+    displayOrder: actionJson.displayOrder ?? 0,
+    config
+  }
+}
+
+/**
+ * @param {string} semanticVersion - e.g. "1.0.0"
+ * @returns {{ major: number, minor: number, patch: number }}
+ */
+function parseSemanticVersion(semanticVersion) {
+  const parts = (semanticVersion ?? '').split('.')
+  return {
+    major: Number.parseInt(parts[0] || '1', 10),
+    minor: Number.parseInt(parts[1] || '0', 10),
+    patch: Number.parseInt(parts[2] || '0', 10)
+  }
+}

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -1,0 +1,126 @@
+import { transformActionConfig } from './action-config.transform.js'
+
+describe('transformActionConfig', () => {
+  const pa3Json = {
+    code: 'PA3',
+    description: 'Woodland management plan',
+    enabled: true,
+    display: false,
+    payment: null,
+    rules: [{ name: 'some-rule', description: 'desc' }],
+    applicationUnitOfMeasurement: 'ha',
+    durationYears: 10,
+    startDate: '2025-01-01',
+    semanticVersion: '1.0.0',
+    displayOrder: 0,
+    paymentMethod: {
+      name: 'wmp-calculation',
+      config: { tiers: [] }
+    }
+  }
+
+  test('extracts code and semanticVersion', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.code).toBe('PA3')
+    expect(result.semanticVersion).toBe('1.0.0')
+  })
+
+  test('parses semantic version into major/minor/patch', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.major).toBe(1)
+    expect(result.minor).toBe(0)
+    expect(result.patch).toBe(0)
+  })
+
+  test('parses non-zero semantic version parts', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      semanticVersion: '2.3.4'
+    })
+    expect(result.major).toBe(2)
+    expect(result.minor).toBe(3)
+    expect(result.patch).toBe(4)
+  })
+
+  test('extracts displayOrder', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.displayOrder).toBe(0)
+  })
+
+  test('defaults displayOrder to 0 when missing', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      displayOrder: undefined
+    })
+    expect(result.displayOrder).toBe(0)
+  })
+
+  test('maps camelCase fields to snake_case config JSONB keys', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.config).toEqual({
+      start_date: '2025-01-01',
+      application_unit_of_measurement: 'ha',
+      duration_years: 10,
+      payment: null,
+      payment_method: { name: 'wmp-calculation', config: { tiers: [] } },
+      land_cover_class_codes: [],
+      rules: [{ name: 'some-rule', description: 'desc' }]
+    })
+  })
+
+  test('defaults landCoverClassCodes to empty array when absent', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      landCoverClassCodes: undefined
+    })
+    expect(result.config.land_cover_class_codes).toEqual([])
+  })
+
+  test('preserves provided landCoverClassCodes', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      landCoverClassCodes: ['GRASS']
+    })
+    expect(result.config.land_cover_class_codes).toEqual(['GRASS'])
+  })
+
+  test('leaves optional config fields undefined when absent from input', () => {
+    const result = transformActionConfig({
+      code: 'PA3',
+      semanticVersion: '1.0.0',
+      payment: undefined,
+      rules: undefined
+    })
+    expect(result.config.start_date).toBeUndefined()
+    expect(result.config.application_unit_of_measurement).toBeUndefined()
+    expect(result.config.duration_years).toBeUndefined()
+    expect(result.config.payment_method).toBeUndefined()
+    expect(result.config.rules).toEqual([])
+  })
+
+  test('defaults major/minor/patch to 1/0/0 when semanticVersion is missing', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      semanticVersion: undefined
+    })
+    expect(result.major).toBe(1)
+    expect(result.minor).toBe(0)
+    expect(result.patch).toBe(0)
+  })
+
+  test('defaults minor/patch to 0 when semanticVersion has fewer than 3 parts', () => {
+    const result = transformActionConfig({ ...pa3Json, semanticVersion: '2' })
+    expect(result.major).toBe(2)
+    expect(result.minor).toBe(0)
+    expect(result.patch).toBe(0)
+  })
+
+  test('config does not include top-level action metadata fields', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.config).not.toHaveProperty('code')
+    expect(result.config).not.toHaveProperty('semanticVersion')
+    expect(result.config).not.toHaveProperty('displayOrder')
+    expect(result.config).not.toHaveProperty('enabled')
+    expect(result.config).not.toHaveProperty('description')
+  })
+})

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -101,13 +101,13 @@ describe('transformActionConfig', () => {
   test('throws when semanticVersion is missing', () => {
     expect(() =>
       transformActionConfig({ ...pa3Json, semanticVersion: undefined })
-    ).toThrow('semanticVersion is required')
+    ).toThrow('Invalid action config')
   })
 
   test('throws when semanticVersion is null', () => {
     expect(() =>
       transformActionConfig({ ...pa3Json, semanticVersion: null })
-    ).toThrow('semanticVersion is required')
+    ).toThrow('Invalid action config')
   })
 
   test('throws when semanticVersion contains non-numeric parts', () => {
@@ -130,6 +130,46 @@ describe('transformActionConfig', () => {
       semanticVersion: '3.1.4'
     })
     expect(result.semanticVersion).toBe('3.1.4')
+  })
+
+  describe('schema validation', () => {
+    test('throws when code is missing', () => {
+      expect(() =>
+        transformActionConfig({ ...pa3Json, code: undefined })
+      ).toThrow('"code" is required')
+    })
+
+    test('collects multiple errors when both required fields are absent', () => {
+      expect(() =>
+        transformActionConfig({
+          ...pa3Json,
+          code: undefined,
+          semanticVersion: undefined
+        })
+      ).toThrow('Invalid action config')
+    })
+
+    test('throws when displayOrder is not a number', () => {
+      expect(() =>
+        transformActionConfig({ ...pa3Json, displayOrder: 'first' })
+      ).toThrow('Invalid action config')
+    })
+
+    test('does not throw for unknown top-level fields', () => {
+      expect(() =>
+        transformActionConfig({
+          ...pa3Json,
+          description: 'extra',
+          enabled: true
+        })
+      ).not.toThrow()
+    })
+
+    test('does not throw when payment is null', () => {
+      expect(() =>
+        transformActionConfig({ ...pa3Json, payment: null })
+      ).not.toThrow()
+    })
   })
 
   test('config does not include top-level action metadata fields', () => {

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -98,21 +98,38 @@ describe('transformActionConfig', () => {
     expect(result.config.rules).toEqual([])
   })
 
-  test('defaults major/minor/patch to 1/0/0 when semanticVersion is missing', () => {
-    const result = transformActionConfig({
-      ...pa3Json,
-      semanticVersion: undefined
-    })
-    expect(result.major).toBe(1)
-    expect(result.minor).toBe(0)
-    expect(result.patch).toBe(0)
+  test('throws when semanticVersion is missing', () => {
+    expect(() =>
+      transformActionConfig({ ...pa3Json, semanticVersion: undefined })
+    ).toThrow('semanticVersion is required')
   })
 
-  test('defaults minor/patch to 0 when semanticVersion has fewer than 3 parts', () => {
+  test('throws when semanticVersion is null', () => {
+    expect(() =>
+      transformActionConfig({ ...pa3Json, semanticVersion: null })
+    ).toThrow('semanticVersion is required')
+  })
+
+  test('throws when semanticVersion contains non-numeric parts', () => {
+    expect(() =>
+      transformActionConfig({ ...pa3Json, semanticVersion: '1.x.0' })
+    ).toThrow('Invalid semanticVersion "1.x.0"')
+  })
+
+  test('normalises partial version to canonical major.minor.patch form', () => {
     const result = transformActionConfig({ ...pa3Json, semanticVersion: '2' })
     expect(result.major).toBe(2)
     expect(result.minor).toBe(0)
     expect(result.patch).toBe(0)
+    expect(result.semanticVersion).toBe('2.0.0')
+  })
+
+  test('normalises semanticVersion to canonical form from parsed parts', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      semanticVersion: '3.1.4'
+    })
+    expect(result.semanticVersion).toBe('3.1.4')
   })
 
   test('config does not include top-level action metadata fields', () => {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,7 @@ import { auth } from '~/src/features/common/plugins/auth.js'
 import { s3Client } from '~/src/features/common/plugins/s3-client.js'
 import { statistics } from '~/src/features/common/plugins/statistics.js'
 import { woodlandManagement } from '~/src/features/woodland-management/index.js'
+import { grantsConfigConsumer } from '~/src/features/grants-config/index.js'
 
 async function createServer() {
   const server = hapi.server({
@@ -45,15 +46,16 @@ async function createServer() {
   })
 
   // Hapi Plugins:
-  // requestLogger  - automatically logs incoming requests
-  // requestTracing - trace header logging and propagation
-  // secureContext  - loads CA certificates from environment config
-  // pulse          - provides shutdown handlers
-  // auth           - provides service-to-service authentication
-  // router         - routes used in the app
-  // s3Client       - S3 client
-  // statistics     - statistics cron job
-  // swagger        - swagger documentation
+  // requestLogger       - automatically logs incoming requests
+  // requestTracing      - trace header logging and propagation
+  // secureContext       - loads CA certificates from environment config
+  // pulse               - provides shutdown handlers
+  // auth                - provides service-to-service authentication
+  // router              - routes used in the app
+  // s3Client            - S3 client
+  // statistics          - statistics cron job
+  // grantsConfig        - SQS consumer for grants-config-broker updates
+  // swagger             - swagger documentation
   await server.register([
     requestLogger,
     requestTracing,
@@ -64,7 +66,8 @@ async function createServer() {
     router,
     s3Client,
     statistics,
-    woodlandManagement
+    woodlandManagement,
+    grantsConfigConsumer
   ])
 
   // Register swagger separately as it needs Inert and Vision plugins


### PR DESCRIPTION
Consumes messages from the grants_config_broker_update queue.
Filters for `land-grants` only, checks if the action config version
already exists in the DB, and if not downloads from S3 and inserts it —
deactivating the previously active row in the same transaction, to keep
with legacy code/logic

Exposes config via env vars for both local and Docker Compose environments,
connecting to the grants-config-broker S3 and SNS instances (via
`Localstack`/`Flocci`) locally.

Added a README section on how to integrate with the grants-config-broker locally.

Additional work:
* fix: file formatting caused by the migrations work