### PR TITLE
GSPS-353 Insert new action code in `actions` table

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v3
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Approve patch and minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'

--- a/README.md
+++ b/README.md
@@ -149,47 +149,63 @@ npm run docker:localstack:up
 
 #### Testing the grants-config-broker SQS integration
 
-Section on how to locally test the end-to-end flow:
-`grants-config-broker` → SNS → SQS → `land-grants-api`
+End-to-end local test flow: `grants-config-broker` → SNS → SQS → `land-grants-api`
 
 ##### Prerequisites
 
-AWS CLI must be installed. Set these env vars once per terminal session to avoid passing credentials on every command:
-
-```bash
-export AWS_ACCESS_KEY_ID=test
-export AWS_SECRET_ACCESS_KEY=test
-export AWS_REGION=eu-west-2
-export AWS_ENDPOINT_URL=http://localhost:4566
-```
+- AWS CLI installed
+- `../grants-config-broker` and `../land-grants-config` checked out as siblings of this repo
 
 ##### 1. Start the land-grants-api stack
 
 ```bash
-
-# Run the setup script
 npm run dev:setup
-
-# Start the API
 npm run dev
 ```
 
-##### 2. Start the grants-config-broker and its mongodb
+##### 2. Run the config-broker helper script
 
-The script below will also prepare the grants-config-broker config directory
-
-**Note:**
-The idempotency check will skip versions already present in the DB.
-To exercise the insert path, bump the land_grants_config_version and `land_action_semantic_version` parameters.
+`scripts/start-config-broker.sh` manages the broker's config directory and starts the service. Run with `--help` to see all options:
 
 ```bash
-./scripts/start-config-broker.sh {land_grants_config_version} {land_action_semantic_version}
+./scripts/start-config-broker.sh --help
+```
 
-Example:
-./scripts/start-config-broker.sh 0.0.6 1.4.0
+###### Subcommands
+
+| Subcommand                   | Description                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------ |
+| _(no args)_                  | Start the broker with no config changes (useful for a restart)                       |
+| `add <version> <sem-ver>`    | Create a synthetic **TEST01** action config and start the broker                     |
+| `update <version> <sem-ver>` | Copy PA3 from `land-grants-config`, set a new semantic version, and start the broker |
+| `inspect`                    | Print SQS queues, S3 bucket contents, and `actions_config` DB rows — then exit       |
+
+> **Idempotency:** the broker skips versions already recorded in MongoDB. Bump `<version>` or `<sem-ver>` to exercise the insert path again.
+
+###### Examples
+
+```bash
+# Publish a brand-new action code (TEST01) and start the broker
+./scripts/start-config-broker.sh add 0.0.5 1.0.0
+
+# Republish PA3 with a new semantic version and start the broker
+./scripts/start-config-broker.sh update 0.0.6 2.0.0
+
+# Restart the broker without touching config (previous run's files still in place)
+./scripts/start-config-broker.sh
+
+# Check what landed in LocalStack and the DB
+./scripts/start-config-broker.sh inspect
 ```
 
 ##### Useful AWS CLI commands
+
+> The script exports LocalStack credentials automatically. If you run these commands in a separate terminal, set them first:
+>
+> ```bash
+> export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+>        AWS_REGION=eu-west-2 AWS_ENDPOINT_URL=http://localhost:4566
+> ```
 
 **List SQS queues:**
 
@@ -215,7 +231,7 @@ aws s3 ls s3://configs-bucket --recursive
 **Inspect a config file directly from S3:**
 
 ```bash
-aws s3 cp s3://configs-bucket/land-grants/0.0.3/actions/PA3/pa3-1.0.1.json -
+aws s3 cp s3://configs-bucket/land-grants/0.0.5/actions/PA3/pa3-2.0.0.json -
 ```
 
 **Manually publish an SNS message** (useful when re-testing without restarting the broker — the broker will not re-deploy a version it has already recorded in MongoDB):
@@ -223,21 +239,21 @@ aws s3 cp s3://configs-bucket/land-grants/0.0.3/actions/PA3/pa3-1.0.1.json -
 ```bash
 aws sns publish \
   --topic-arn arn:aws:sns:eu-west-2:000000000000:gfr__sns___config_update \
-  --message '["land-grants/0.0.3/actions/PA3/pa3-1.0.1.json","land-grants/0.0.3/metadata.json"]' \
+  --message '["land-grants/0.0.5/actions/PA3/pa3-2.0.0.json","land-grants/0.0.5/metadata.json"]' \
   --message-attributes '{
     "grant":   {"DataType":"String","StringValue":"land-grants"},
-    "version": {"DataType":"String","StringValue":"0.0.3"},
+    "version": {"DataType":"String","StringValue":"0.0.5"},
     "status":  {"DataType":"String","StringValue":"active"},
     "path":    {"DataType":"String","StringValue":"s3://configs-bucket"}
   }'
 ```
 
-**Verify the DB row was inserted or updated:**
+**Verify DB rows were inserted or updated:**
 
 ```bash
 docker exec -it land-grants-api-land-grants-backend-postgres-1 psql \
   -U land_grants_api -d land_grants_api \
-  -c "SELECT code, semantic_version, version, is_active FROM actions_config WHERE code = 'PA3' ORDER BY id;"
+  -c "SELECT code, semantic_version, version, is_active FROM actions_config WHERE code IN ('PA3','TEST01') ORDER BY code, id;"
 ```
 
 #### Local data

--- a/scripts/start-config-broker.sh
+++ b/scripts/start-config-broker.sh
@@ -2,15 +2,6 @@
 # Starts the grants-config-broker against the land-grants-api's LocalStack (floci) to test the
 # end-to-end flow: grants-config-broker → SNS → SQS → land-grants-api.
 #
-# Usage:
-#   ./scripts/start-config-broker.sh [grant-version] [semantic-version]
-#   ./scripts/start-config-broker.sh inspect
-#
-# Arguments:
-#   grant-version     Release version written to config/release.yml (e.g. 0.0.4). Prompted if omitted.
-#   semantic-version  Optional. Overrides the semanticVersion field and filename in all action JSON files.
-#   inspect           Prints SQS queues, S3 bucket contents, and the actions_config DB rows then exits.
-#
 # Prerequisites: land-grants-api stack must be running (docker compose up floci floci-init ... -d).
 set -euo pipefail
 
@@ -25,91 +16,196 @@ GRANT_NAME="land-grants"
 GRANT_CONFIG_SOURCE="../land-grants-config/$GRANT_NAME"
 
 # ---------------------------------------------------------------------------
-# inspect mode
+# Splash / help
 # ---------------------------------------------------------------------------
 
-if [[ "${1:-}" == "inspect" ]]; then
-  echo "=== SQS queues ==="
-  aws sqs list-queues |  xargs echo
+BOLD='\033[1m'
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RESET='\033[0m'
 
-  echo ""
-  echo "=== S3 configs-bucket ==="
-  aws s3 ls s3://configs-bucket --recursive
+print_splash() {
+  echo -e "${CYAN}"
+  echo '  ██████╗ ██████╗  █████╗ ███╗   ██╗████████╗███████╗'
+  echo ' ██╔════╝ ██╔══██╗██╔══██╗████╗  ██║╚══██╔══╝██╔════╝'
+  echo ' ██║  ███╗██████╔╝███████║██╔██╗ ██║   ██║   ███████╗'
+  echo ' ██║   ██║██╔══██╗██╔══██║██║╚██╗██║   ██║   ╚════██║'
+  echo ' ╚██████╔╝██║  ██║██║  ██║██║ ╚████║   ██║   ███████║'
+  echo '  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚══════╝'
+  echo -e "${RESET}"
+  echo -e "  ${BOLD}config-broker local runner${RESET}  ·  land-grants ↔ LocalStack (floci)"
+  echo
+}
 
-  echo ""
-  echo "=== actions_config (PA3) ==="
-  docker exec land-grants-api-land-grants-backend-postgres-1 psql \
-    -U land_grants_api -d land_grants_api \
-    -c "SELECT code, semantic_version, version, is_active FROM actions_config WHERE code = 'PA3' ORDER BY id;"
-
-  exit 0
-fi
+print_help() {
+  print_splash
+  echo -e "${BOLD}USAGE${RESET}"
+  echo "  $(basename "$0") [subcommand] [arguments]"
+  echo
+  echo -e "${BOLD}SUBCOMMANDS${RESET}"
+  echo -e "  ${GREEN}(no args)${RESET}                          Start the broker without any config setup"
+  echo -e "  ${GREEN}add${RESET} <grant-version> <sem-ver>     Create a TEST01 action config and start"
+  echo -e "  ${GREEN}update${RESET} <grant-version> <sem-ver>  Republish PA3 with a new semantic version and start"
+  echo -e "  ${GREEN}inspect${RESET}                           Print SQS queues, S3 contents, and DB rows then exit"
+  echo -e "  ${GREEN}-h${RESET}, ${GREEN}--help${RESET}                        Show this help message"
+  echo
+  echo -e "${BOLD}EXAMPLES${RESET}"
+  echo "  $(basename "$0")                        # restart broker, no config changes"
+  echo "  $(basename "$0") add 0.0.5 1.0.0        # publish TEST01 v1.0.0 under grant release 0.0.5"
+  echo "  $(basename "$0") update 0.0.6 2.0.0     # republish PA3 with semanticVersion 2.0.0"
+  echo "  $(basename "$0") inspect                # inspect current LocalStack (floci) + DB state"
+  echo
+}
 
 # ---------------------------------------------------------------------------
-# 1. Prepare release
+# Helpers
 # ---------------------------------------------------------------------------
 
-GRANT_VERSION="${1:-}"
-SEMANTIC_VERSION="${2:-}"
-
-if [[ -z "$GRANT_VERSION" ]]; then
-  read -rp "Grant version to release (e.g. 0.0.4): " GRANT_VERSION
-fi
-
-CONFIG_DIR="$BROKER_DIR/config"
-VERSIONED_DIR="$CONFIG_DIR/${GRANT_NAME}@${GRANT_VERSION}"
-
-mkdir -p "$CONFIG_DIR"
-
-cat > "$CONFIG_DIR/release.yml" << EOF
+make_release_yml() {
+  local grant_version="$1"
+  local config_dir="$BROKER_DIR/config"
+  mkdir -p "$config_dir"
+  cat > "$config_dir/release.yml" << EOF
 name: $GRANT_NAME
-version: $GRANT_VERSION
+version: $grant_version
 notes: Local test
 environments:
   - name: dev
     status: active
 EOF
+  echo -e "  ${YELLOW}release.yml${RESET}   $config_dir/release.yml"
+}
 
-mkdir -p "$VERSIONED_DIR"
-cp -r "$GRANT_CONFIG_SOURCE/." "$VERSIONED_DIR/"
+start_broker() {
+  docker network create grants-framework 2>/dev/null || true
+  docker compose -f "$COMPOSE_FILE" up mongodb -d --wait
 
-if [[ -n "$SEMANTIC_VERSION" ]]; then
-  find "$VERSIONED_DIR" -name "*.json" | while read -r file; do
-    dir=$(dirname "$file")
-    basename=$(basename "$file")
-    old_version=$(jq -r '.semanticVersion' "$file")
-    new_basename="${basename/$old_version/$SEMANTIC_VERSION}"
-    jq --arg v "$SEMANTIC_VERSION" '.semanticVersion = $v' "$file" > "$dir/$new_basename"
-    [[ "$basename" != "$new_basename" ]] && rm -f "$file"
-  done
-  echo "semanticVersion:  $SEMANTIC_VERSION (content + filenames updated)"
-fi
+  echo
+  echo -e "  ${BOLD}Starting broker on port 3002 …${RESET}"
+  echo
 
-echo "Release manifest: $CONFIG_DIR/release.yml"
-echo "Config files:     $VERSIONED_DIR"
-
-# ---------------------------------------------------------------------------
-# 2. Start infrastructure
-# ---------------------------------------------------------------------------
-
-# Ensure the shared Docker network exists (no-op if already present)
-docker network create grants-framework 2>/dev/null || true
-
-# --wait blocks until the LocalStack healthcheck passes.
-docker compose -f "$COMPOSE_FILE" up mongodb -d --wait
+  # Run on port 3002 (land-grants-api uses 3001).
+  # SERVICE_VERSION uses a timestamp so MongoDB's duplicate-key guard does not
+  # block repeated restarts.
+  cd "$BROKER_DIR"
+  PORT=3002 \
+    AWS_ENDPOINT_URL=http://localhost:4566 \
+    ENVIRONMENT=dev \
+    CONFIG_BUCKET_NAME=configs-bucket \
+    MONGO_URI=mongodb://127.0.0.1:27017/ \
+    SERVICE_VERSION="local-$(date +%s)" \
+    npm run dev
+}
 
 # ---------------------------------------------------------------------------
-# 3. Start the broker
+# Subcommands
 # ---------------------------------------------------------------------------
 
-# Run on port 3002 (land-grants-api uses 3001).
-# SERVICE_VERSION uses a timestamp so MongoDB's duplicate-key guard does not
-# block repeated restarts.
-cd "$BROKER_DIR"
-PORT=3002 \
-  AWS_ENDPOINT_URL=http://localhost:4566 \
-  ENVIRONMENT=dev \
-  CONFIG_BUCKET_NAME=configs-bucket \
-  MONGO_URI=mongodb://127.0.0.1:27017/ \
-  SERVICE_VERSION="local-$(date +%s)" \
-  npm run dev
+case "${1:-}" in
+
+  -h|--help)
+    print_help
+    exit 0
+    ;;
+
+  inspect)
+    print_splash
+    echo "=== SQS queues ==="
+    aws sqs list-queues | xargs echo
+
+    echo ""
+    echo "=== S3 configs-bucket ==="
+    aws s3 ls s3://configs-bucket --recursive
+
+    echo ""
+    echo "=== actions_config (PA3, TEST01) ==="
+    docker exec land-grants-api-land-grants-backend-postgres-1 psql \
+      -U land_grants_api -d land_grants_api \
+      -c "SELECT code, semantic_version, version, is_active FROM actions_config WHERE code IN ('PA3','TEST01') ORDER BY code, id;"
+
+    exit 0
+    ;;
+
+  add)
+    GRANT_VERSION="${2:-}"
+    SEMANTIC_VERSION="${3:-}"
+    if [[ -z "$GRANT_VERSION" || -z "$SEMANTIC_VERSION" ]]; then
+      echo -e "${BOLD}Usage:${RESET} $0 add <grant-version> <semantic-version>" >&2
+      exit 1
+    fi
+
+    print_splash
+    echo -e "  ${BOLD}Mode:${RESET} add TEST01 @ ${SEMANTIC_VERSION} (grant ${GRANT_VERSION})"
+    echo
+
+    VERSIONED_DIR="$BROKER_DIR/config/${GRANT_NAME}@${GRANT_VERSION}"
+    make_release_yml "$GRANT_VERSION"
+
+    mkdir -p "$VERSIONED_DIR/actions/TEST01"
+    cat > "$VERSIONED_DIR/actions/TEST01/test01-${SEMANTIC_VERSION}.json" << EOF
+{
+  "code": "TEST01",
+  "semanticVersion": "$SEMANTIC_VERSION",
+  "startDate": "2025-01-01",
+  "applicationUnitOfMeasurement": "ha",
+  "durationYears": 3,
+  "payment": null,
+  "paymentMethod": null,
+  "landCoverClassCodes": [],
+  "rules": [],
+  "sssiEligible": true,
+  "hfEligible": true,
+  "groupId": null,
+  "displayOrder": 0
+}
+EOF
+    echo -e "  ${YELLOW}action config${RESET} $VERSIONED_DIR/actions/TEST01/test01-${SEMANTIC_VERSION}.json"
+
+    start_broker
+    ;;
+
+  update)
+    GRANT_VERSION="${2:-}"
+    SEMANTIC_VERSION="${3:-}"
+    if [[ -z "$GRANT_VERSION" || -z "$SEMANTIC_VERSION" ]]; then
+      echo -e "${BOLD}Usage:${RESET} $0 update <grant-version> <semantic-version>" >&2
+      exit 1
+    fi
+
+    print_splash
+    echo -e "  ${BOLD}Mode:${RESET} update PA3 → semanticVersion ${SEMANTIC_VERSION} (grant ${GRANT_VERSION})"
+    echo
+
+    VERSIONED_DIR="$BROKER_DIR/config/${GRANT_NAME}@${GRANT_VERSION}"
+    make_release_yml "$GRANT_VERSION"
+
+    mkdir -p "$VERSIONED_DIR/actions/PA3"
+    cp "$GRANT_CONFIG_SOURCE/actions/PA3/"*.json "$VERSIONED_DIR/actions/PA3/"
+
+    find "$VERSIONED_DIR/actions/PA3" -name "*.json" | while read -r file; do
+      dir=$(dirname "$file")
+      basename=$(basename "$file")
+      old_version=$(jq -r '.semanticVersion' "$file")
+      new_basename="${basename/$old_version/$SEMANTIC_VERSION}"
+      jq --arg v "$SEMANTIC_VERSION" '.semanticVersion = $v' "$file" > "$dir/$new_basename"
+      [[ "$basename" != "$new_basename" ]] && rm -f "$file"
+    done
+    echo -e "  ${YELLOW}action config${RESET} $VERSIONED_DIR/actions/PA3/ (semanticVersion → $SEMANTIC_VERSION)"
+
+    start_broker
+    ;;
+
+  "")
+    print_splash
+    echo -e "  ${BOLD}Mode:${RESET} start only (no config setup)"
+    start_broker
+    ;;
+
+  *)
+    echo -e "${BOLD}Unknown subcommand:${RESET} ${1}" >&2
+    echo "Run '$(basename "$0") --help' for usage." >&2
+    exit 1
+    ;;
+
+esac

--- a/src/features/grants-config/queries/insertActionConfig.query.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.js
@@ -6,7 +6,7 @@ import { logDatabaseError } from '~/src/features/common/helpers/logging/log-help
  * then inserts the new row with is_active=TRUE.
  * @param {import('~/src/features/common/logger.d.js').Logger} logger
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
- * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean }} params
+ * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, groupId: number|null }} params
  * @returns {Promise<boolean>} true on success
  */
 async function insertActionConfig(logger, db, params) {
@@ -18,7 +18,8 @@ async function insertActionConfig(logger, db, params) {
     patch,
     displayOrder,
     sssiEligible,
-    hfEligible
+    hfEligible,
+    groupId
   } = params
   let client
   try {
@@ -41,13 +42,13 @@ async function insertActionConfig(logger, db, params) {
 
     await client.query(
       `INSERT INTO actions_config
-         (code, version, config, is_active, last_updated_at, major_version, minor_version, patch_version, display_order)
+         (code, version, config, is_active, last_updated_at, major_version, minor_version, patch_version, display_order, group_id)
        VALUES (
          $1,
          (SELECT CAST(COALESCE(MAX(version::integer), 0) + 1 AS text) FROM actions_config WHERE code = $1),
-         $2, TRUE, NOW(), $3, $4, $5, $6
+         $2, TRUE, NOW(), $3, $4, $5, $6, $7
        )`,
-      [code, JSON.stringify(config), major, minor, patch, displayOrder]
+      [code, JSON.stringify(config), major, minor, patch, displayOrder, groupId]
     )
 
     await client.query('COMMIT')

--- a/src/features/grants-config/queries/insertActionConfig.query.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.js
@@ -6,15 +6,33 @@ import { logDatabaseError } from '~/src/features/common/helpers/logging/log-help
  * then inserts the new row with is_active=TRUE.
  * @param {import('~/src/features/common/logger.d.js').Logger} logger
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
- * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number }} params
+ * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean }} params
  * @returns {Promise<boolean>} true on success
  */
 async function insertActionConfig(logger, db, params) {
-  const { code, config, major, minor, patch, displayOrder } = params
+  const {
+    code,
+    config,
+    major,
+    minor,
+    patch,
+    displayOrder,
+    sssiEligible,
+    hfEligible
+  } = params
   let client
   try {
     client = await db.connect()
     await client.query('BEGIN')
+
+    await client.query(
+      `INSERT INTO actions (code, enabled, display, sssi_eligible, hf_eligible)
+       VALUES ($1, TRUE, TRUE, $2, $3)
+       ON CONFLICT (code) DO UPDATE SET
+         sssi_eligible = EXCLUDED.sssi_eligible,
+         hf_eligible = EXCLUDED.hf_eligible`,
+      [code, sssiEligible, hfEligible]
+    )
 
     await client.query(
       'UPDATE actions_config SET is_active = FALSE WHERE code = $1 AND is_active = TRUE',

--- a/src/features/grants-config/queries/insertActionConfig.query.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.js
@@ -6,7 +6,7 @@ import { logDatabaseError } from '~/src/features/common/helpers/logging/log-help
  * then inserts the new row with is_active=TRUE.
  * @param {import('~/src/features/common/logger.d.js').Logger} logger
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
- * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, groupId: number|null }} params
+ * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, description: string|null, sssiEligible: boolean, hfEligible: boolean, groupId: number|null }} params
  * @returns {Promise<boolean>} true on success
  */
 async function insertActionConfig(logger, db, params) {
@@ -17,6 +17,7 @@ async function insertActionConfig(logger, db, params) {
     minor,
     patch,
     displayOrder,
+    description,
     sssiEligible,
     hfEligible,
     groupId
@@ -27,12 +28,13 @@ async function insertActionConfig(logger, db, params) {
     await client.query('BEGIN')
 
     await client.query(
-      `INSERT INTO actions (code, enabled, display, sssi_eligible, hf_eligible)
-       VALUES ($1, TRUE, TRUE, $2, $3)
+      `INSERT INTO actions (code, enabled, display, description, sssi_eligible, hf_eligible)
+       VALUES ($1, TRUE, TRUE, $2, $3, $4)
        ON CONFLICT (code) DO UPDATE SET
+         description = COALESCE(EXCLUDED.description, actions.description),
          sssi_eligible = EXCLUDED.sssi_eligible,
          hf_eligible = EXCLUDED.hf_eligible`,
-      [code, sssiEligible, hfEligible]
+      [code, description, sssiEligible, hfEligible]
     )
 
     await client.query(

--- a/src/features/grants-config/queries/insertActionConfig.query.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.js
@@ -2,8 +2,9 @@ import { logDatabaseError } from '~/src/features/common/helpers/logging/log-help
 
 /**
  * Insert a new action config version into the DB.
- * Wraps in a transaction: deactivates the existing active row first,
- * then inserts the new row with is_active=TRUE.
+ * Wraps in a transaction: deactivates the existing active row only when the
+ * new semantic version is strictly higher, then inserts the new row.
+ * is_active on the new row is TRUE only if no active row remains after the UPDATE.
  * @param {import('~/src/features/common/logger.d.js').Logger} logger
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
  * @param {{ code: string, config: object, major: number, minor: number, patch: number, displayOrder: number, description: string|null, sssiEligible: boolean, hfEligible: boolean, groupId: number|null }} params
@@ -38,8 +39,16 @@ async function insertActionConfig(logger, db, params) {
     )
 
     await client.query(
-      'UPDATE actions_config SET is_active = FALSE WHERE code = $1 AND is_active = TRUE',
-      [code]
+      `UPDATE actions_config
+       SET is_active = FALSE
+       WHERE code = $1
+         AND is_active = TRUE
+         AND (
+           $2 > major_version
+           OR ($2 = major_version AND $3 > minor_version)
+           OR ($2 = major_version AND $3 = minor_version AND $4 > patch_version)
+         )`,
+      [code, major, minor, patch]
     )
 
     await client.query(
@@ -48,7 +57,9 @@ async function insertActionConfig(logger, db, params) {
        VALUES (
          $1,
          (SELECT CAST(COALESCE(MAX(version::integer), 0) + 1 AS text) FROM actions_config WHERE code = $1),
-         $2, TRUE, NOW(), $3, $4, $5, $6, $7
+         $2,
+         NOT EXISTS(SELECT 1 FROM actions_config WHERE code = $1 AND is_active = TRUE),
+         NOW(), $3, $4, $5, $6, $7
        )`,
       [code, JSON.stringify(config), major, minor, patch, displayOrder, groupId]
     )

--- a/src/features/grants-config/queries/insertActionConfig.query.test.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.test.js
@@ -40,7 +40,7 @@ describe('insertActionConfig', () => {
     )
     expect(calls[0]).toBe('BEGIN')
     expect(calls[1]).toContain('INSERT INTO actions')
-    expect(calls[2]).toContain('UPDATE actions_config SET is_active = FALSE')
+    expect(calls[2]).toContain('UPDATE actions_config')
     expect(calls[3]).toContain('INSERT INTO actions_config')
     expect(calls[4]).toBe('COMMIT')
   })
@@ -111,12 +111,29 @@ describe('insertActionConfig', () => {
     expect(upsertCall[0]).toContain('hf_eligible = EXCLUDED.hf_eligible')
   })
 
-  test('deactivates existing active config for the same code', async () => {
+  test('deactivates existing active config only when new version is higher', async () => {
     await insertActionConfig(mockLogger, mockDb, params)
 
-    expect(mockClient.query).toHaveBeenCalledWith(
-      'UPDATE actions_config SET is_active = FALSE WHERE code = $1 AND is_active = TRUE',
-      ['PA3']
+    const updateCall = mockClient.query.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE actions_config')
+    )
+    expect(updateCall).toBeDefined()
+    // WHERE clause guards on major/minor/patch so a lower version never deactivates the active row
+    expect(updateCall[0]).toContain('major_version')
+    expect(updateCall[0]).toContain('minor_version')
+    expect(updateCall[0]).toContain('patch_version')
+    expect(updateCall[1]).toEqual(['PA3', 1, 0, 0])
+  })
+
+  test('inserts new row with is_active derived from NOT EXISTS subquery', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    const insertCall = mockClient.query.mock.calls.find(
+      (c) =>
+        typeof c[0] === 'string' && c[0].includes('INSERT INTO actions_config')
+    )
+    expect(insertCall[0]).toContain(
+      'NOT EXISTS(SELECT 1 FROM actions_config WHERE code = $1 AND is_active = TRUE)'
     )
   })
 

--- a/src/features/grants-config/queries/insertActionConfig.query.test.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.test.js
@@ -13,7 +13,8 @@ describe('insertActionConfig', () => {
     patch: 0,
     displayOrder: 0,
     sssiEligible: true,
-    hfEligible: true
+    hfEligible: true,
+    groupId: null
   }
 
   beforeEach(() => {
@@ -65,6 +66,16 @@ describe('insertActionConfig', () => {
     )
   })
 
+  test('passes groupId to actions_config insert', async () => {
+    await insertActionConfig(mockLogger, mockDb, { ...params, groupId: 3 })
+
+    const insertCall = mockClient.query.mock.calls.find(
+      (c) =>
+        typeof c[0] === 'string' && c[0].includes('INSERT INTO actions_config')
+    )
+    expect(insertCall[1][6]).toBe(3)
+  })
+
   test('updates sssi_eligible and hf_eligible on conflict', async () => {
     await insertActionConfig(mockLogger, mockDb, params)
 
@@ -100,6 +111,7 @@ describe('insertActionConfig', () => {
     expect(insertParams[3]).toBe(0) // minor
     expect(insertParams[4]).toBe(0) // patch
     expect(insertParams[5]).toBe(0) // displayOrder
+    expect(insertParams[6]).toBeNull() // groupId
   })
 
   test('returns true on success', async () => {

--- a/src/features/grants-config/queries/insertActionConfig.query.test.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.test.js
@@ -12,6 +12,7 @@ describe('insertActionConfig', () => {
     minor: 0,
     patch: 0,
     displayOrder: 0,
+    description: 'Woodland management plan',
     sssiEligible: true,
     hfEligible: true,
     groupId: null
@@ -44,12 +45,35 @@ describe('insertActionConfig', () => {
     expect(calls[4]).toBe('COMMIT')
   })
 
-  test('upserts action with sssiEligible and hfEligible from params', async () => {
+  test('upserts action with description, sssiEligible and hfEligible from params', async () => {
     await insertActionConfig(mockLogger, mockDb, params)
 
     expect(mockClient.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO actions'),
-      ['PA3', true, true]
+      ['PA3', 'Woodland management plan', true, true]
+    )
+  })
+
+  test('passes null description when absent', async () => {
+    await insertActionConfig(mockLogger, mockDb, {
+      ...params,
+      description: null
+    })
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO actions'),
+      ['PA3', null, true, true]
+    )
+  })
+
+  test('uses COALESCE so null description does not overwrite existing', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    const upsertCall = mockClient.query.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO actions')
+    )
+    expect(upsertCall[0]).toContain(
+      'COALESCE(EXCLUDED.description, actions.description)'
     )
   })
 
@@ -62,7 +86,7 @@ describe('insertActionConfig', () => {
 
     expect(mockClient.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO actions'),
-      ['PA3', false, false]
+      ['PA3', 'Woodland management plan', false, false]
     )
   })
 

--- a/src/features/grants-config/queries/insertActionConfig.query.test.js
+++ b/src/features/grants-config/queries/insertActionConfig.query.test.js
@@ -11,7 +11,9 @@ describe('insertActionConfig', () => {
     major: 1,
     minor: 0,
     patch: 0,
-    displayOrder: 0
+    displayOrder: 0,
+    sssiEligible: true,
+    hfEligible: true
   }
 
   beforeEach(() => {
@@ -28,16 +30,50 @@ describe('insertActionConfig', () => {
     }
   })
 
-  test('executes BEGIN, UPDATE, INSERT and COMMIT in order', async () => {
+  test('executes BEGIN, upsert actions, UPDATE, INSERT and COMMIT in order', async () => {
     await insertActionConfig(mockLogger, mockDb, params)
 
     const calls = mockClient.query.mock.calls.map((c) =>
       typeof c[0] === 'string' ? c[0].trim() : c[0]
     )
     expect(calls[0]).toBe('BEGIN')
-    expect(calls[1]).toContain('UPDATE actions_config SET is_active = FALSE')
-    expect(calls[2]).toContain('INSERT INTO actions_config')
-    expect(calls[3]).toBe('COMMIT')
+    expect(calls[1]).toContain('INSERT INTO actions')
+    expect(calls[2]).toContain('UPDATE actions_config SET is_active = FALSE')
+    expect(calls[3]).toContain('INSERT INTO actions_config')
+    expect(calls[4]).toBe('COMMIT')
+  })
+
+  test('upserts action with sssiEligible and hfEligible from params', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO actions'),
+      ['PA3', true, true]
+    )
+  })
+
+  test('sets sssi_eligible and hf_eligible to false when params are false', async () => {
+    await insertActionConfig(mockLogger, mockDb, {
+      ...params,
+      sssiEligible: false,
+      hfEligible: false
+    })
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO actions'),
+      ['PA3', false, false]
+    )
+  })
+
+  test('updates sssi_eligible and hf_eligible on conflict', async () => {
+    await insertActionConfig(mockLogger, mockDb, params)
+
+    const upsertCall = mockClient.query.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO actions')
+    )
+    expect(upsertCall[0]).toContain('ON CONFLICT')
+    expect(upsertCall[0]).toContain('sssi_eligible = EXCLUDED.sssi_eligible')
+    expect(upsertCall[0]).toContain('hf_eligible = EXCLUDED.hf_eligible')
   })
 
   test('deactivates existing active config for the same code', async () => {
@@ -79,6 +115,7 @@ describe('insertActionConfig', () => {
   test('rolls back and returns false on INSERT error', async () => {
     mockClient.query
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // INSERT INTO actions (upsert)
       .mockResolvedValueOnce({ rows: [] }) // UPDATE
       .mockRejectedValueOnce(new Error('Insert failed'))
 
@@ -97,10 +134,25 @@ describe('insertActionConfig', () => {
     )
   })
 
+  test('rolls back and returns false when action upsert fails', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockRejectedValueOnce(new Error('FK violation'))
+
+    const result = await insertActionConfig(mockLogger, mockDb, params)
+
+    expect(result).toBe(false)
+    const rollbackCall = mockClient.query.mock.calls.find(
+      (c) => c[0] === 'ROLLBACK'
+    )
+    expect(rollbackCall).toBeDefined()
+  })
+
   test('releases the client after an error', async () => {
     mockClient.query
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // INSERT INTO actions (upsert)
+      .mockResolvedValueOnce({}) // UPDATE
       .mockRejectedValueOnce(new Error('fail'))
       .mockResolvedValueOnce({}) // ROLLBACK
 

--- a/src/features/grants-config/schema/action-config.schema.js
+++ b/src/features/grants-config/schema/action-config.schema.js
@@ -11,6 +11,7 @@ export const actionConfigInputSchema = Joi.object({
   paymentMethod: Joi.object().optional(),
   landCoverClassCodes: Joi.array().items(Joi.string()).optional(),
   rules: Joi.array().items(Joi.object()).optional(),
+  description: Joi.string().optional(),
   sssiEligible: Joi.boolean().optional(),
   hfEligible: Joi.boolean().optional(),
   groupId: Joi.number().integer().optional()

--- a/src/features/grants-config/schema/action-config.schema.js
+++ b/src/features/grants-config/schema/action-config.schema.js
@@ -12,5 +12,6 @@ export const actionConfigInputSchema = Joi.object({
   landCoverClassCodes: Joi.array().items(Joi.string()).optional(),
   rules: Joi.array().items(Joi.object()).optional(),
   sssiEligible: Joi.boolean().optional(),
-  hfEligible: Joi.boolean().optional()
+  hfEligible: Joi.boolean().optional(),
+  groupId: Joi.number().integer().optional()
 }).options({ allowUnknown: true })

--- a/src/features/grants-config/schema/action-config.schema.js
+++ b/src/features/grants-config/schema/action-config.schema.js
@@ -10,5 +10,7 @@ export const actionConfigInputSchema = Joi.object({
   payment: Joi.object().allow(null).optional(),
   paymentMethod: Joi.object().optional(),
   landCoverClassCodes: Joi.array().items(Joi.string()).optional(),
-  rules: Joi.array().items(Joi.object()).optional()
+  rules: Joi.array().items(Joi.object()).optional(),
+  sssiEligible: Joi.boolean().optional(),
+  hfEligible: Joi.boolean().optional()
 }).options({ allowUnknown: true })

--- a/src/features/grants-config/service/grants-config.service.js
+++ b/src/features/grants-config/service/grants-config.service.js
@@ -18,8 +18,17 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
   const response = await getFile(s3Client, bucket, s3Key)
   const json = JSON.parse(await response.Body.transformToString())
 
-  const { code, semanticVersion, major, minor, patch, displayOrder, config } =
-    transformActionConfig(json)
+  const {
+    code,
+    semanticVersion,
+    major,
+    minor,
+    patch,
+    displayOrder,
+    sssiEligible,
+    hfEligible,
+    config
+  } = transformActionConfig(json)
 
   if (!semanticVersion) {
     throw new Error(
@@ -51,7 +60,9 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
     major,
     minor,
     patch,
-    displayOrder
+    displayOrder,
+    sssiEligible,
+    hfEligible
   })
 
   if (!inserted) {

--- a/src/features/grants-config/service/grants-config.service.js
+++ b/src/features/grants-config/service/grants-config.service.js
@@ -27,6 +27,7 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
     displayOrder,
     sssiEligible,
     hfEligible,
+    groupId,
     config
   } = transformActionConfig(json)
 
@@ -62,7 +63,8 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
     patch,
     displayOrder,
     sssiEligible,
-    hfEligible
+    hfEligible,
+    groupId
   })
 
   if (!inserted) {

--- a/src/features/grants-config/service/grants-config.service.js
+++ b/src/features/grants-config/service/grants-config.service.js
@@ -25,6 +25,7 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
     minor,
     patch,
     displayOrder,
+    description,
     sssiEligible,
     hfEligible,
     groupId,
@@ -62,6 +63,7 @@ async function processActionConfigFile(logger, s3Client, db, s3Key, bucket) {
     minor,
     patch,
     displayOrder,
+    description,
     sssiEligible,
     hfEligible,
     groupId

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -4,7 +4,7 @@ import { actionConfigInputSchema } from '../schema/action-config.schema.js'
  * Transform an action config JSON (camelCase from land-grants-config repo)
  * into the shape stored in the actions_config DB table.
  * @param {object} actionJson - Raw action JSON from S3
- * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, config: object }}
+ * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, config: object }}
  */
 export function transformActionConfig(actionJson) {
   const { error } = actionConfigInputSchema.validate(actionJson)
@@ -35,6 +35,8 @@ export function transformActionConfig(actionJson) {
     minor,
     patch,
     displayOrder: actionJson.displayOrder ?? 0,
+    sssiEligible: actionJson.sssiEligible ?? true,
+    hfEligible: actionJson.hfEligible ?? true,
     config
   }
 }

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -4,7 +4,7 @@ import { actionConfigInputSchema } from '../schema/action-config.schema.js'
  * Transform an action config JSON (camelCase from land-grants-config repo)
  * into the shape stored in the actions_config DB table.
  * @param {object} actionJson - Raw action JSON from S3
- * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, config: object }}
+ * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, groupId: number|null, config: object }}
  */
 export function transformActionConfig(actionJson) {
   const { error } = actionConfigInputSchema.validate(actionJson)
@@ -37,6 +37,7 @@ export function transformActionConfig(actionJson) {
     displayOrder: actionJson.displayOrder ?? 0,
     sssiEligible: actionJson.sssiEligible ?? true,
     hfEligible: actionJson.hfEligible ?? true,
+    groupId: actionJson.groupId ?? null,
     config
   }
 }

--- a/src/features/grants-config/transforms/action-config.transform.js
+++ b/src/features/grants-config/transforms/action-config.transform.js
@@ -4,7 +4,7 @@ import { actionConfigInputSchema } from '../schema/action-config.schema.js'
  * Transform an action config JSON (camelCase from land-grants-config repo)
  * into the shape stored in the actions_config DB table.
  * @param {object} actionJson - Raw action JSON from S3
- * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, sssiEligible: boolean, hfEligible: boolean, groupId: number|null, config: object }}
+ * @returns {{ code: string, semanticVersion: string, major: number, minor: number, patch: number, displayOrder: number, description: string|null, sssiEligible: boolean, hfEligible: boolean, groupId: number|null, config: object }}
  */
 export function transformActionConfig(actionJson) {
   const { error } = actionConfigInputSchema.validate(actionJson)
@@ -35,6 +35,7 @@ export function transformActionConfig(actionJson) {
     minor,
     patch,
     displayOrder: actionJson.displayOrder ?? 0,
+    description: actionJson.description ?? null,
     sssiEligible: actionJson.sssiEligible ?? true,
     hfEligible: actionJson.hfEligible ?? true,
     groupId: actionJson.groupId ?? null,

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -55,6 +55,26 @@ describe('transformActionConfig', () => {
     expect(result.displayOrder).toBe(0)
   })
 
+  test('extracts sssiEligible and hfEligible when present', () => {
+    const result = transformActionConfig({
+      ...pa3Json,
+      sssiEligible: false,
+      hfEligible: false
+    })
+    expect(result.sssiEligible).toBe(false)
+    expect(result.hfEligible).toBe(false)
+  })
+
+  test('defaults sssiEligible to true when absent', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.sssiEligible).toBe(true)
+  })
+
+  test('defaults hfEligible to true when absent', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.hfEligible).toBe(true)
+  })
+
   test('maps camelCase fields to snake_case config JSONB keys', () => {
     const result = transformActionConfig(pa3Json)
     expect(result.config).toEqual({

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -75,6 +75,16 @@ describe('transformActionConfig', () => {
     expect(result.hfEligible).toBe(true)
   })
 
+  test('extracts groupId when present', () => {
+    const result = transformActionConfig({ ...pa3Json, groupId: 2 })
+    expect(result.groupId).toBe(2)
+  })
+
+  test('defaults groupId to null when absent', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.groupId).toBeNull()
+  })
+
   test('maps camelCase fields to snake_case config JSONB keys', () => {
     const result = transformActionConfig(pa3Json)
     expect(result.config).toEqual({

--- a/src/features/grants-config/transforms/action-config.transform.test.js
+++ b/src/features/grants-config/transforms/action-config.transform.test.js
@@ -55,6 +55,16 @@ describe('transformActionConfig', () => {
     expect(result.displayOrder).toBe(0)
   })
 
+  test('extracts description when present', () => {
+    const result = transformActionConfig(pa3Json)
+    expect(result.description).toBe('Woodland management plan')
+  })
+
+  test('defaults description to null when absent', () => {
+    const result = transformActionConfig({ ...pa3Json, description: undefined })
+    expect(result.description).toBeNull()
+  })
+
   test('extracts sssiEligible and hfEligible when present', () => {
     const result = transformActionConfig({
       ...pa3Json,


### PR DESCRIPTION
* populates `sssi_eligible` and `hf_eligible` reading it from the land-grants-config JSON files and defaults to true if not present.
* Insert new action code in actions table
* populate an existing groupId
* Add config broker script to add new action code, update existing one and just start the server
* only update `is_active` if new semver is higher than existing one