### PR TITLE
GSPS-353 Remove validation of message type 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -72,6 +72,7 @@ services:
       GRANTS_CONFIG_QUEUE_URL: http://floci:4566/000000000000/grants_config_broker_update
       GRANTS_CONFIG_BUCKET: configs-bucket
       SQS_ENDPOINT: http://floci:4566
+      S3_ENDPOINT: http://floci:4566
     volumes:
       - ./src:/home/node/src
       - node_deps:/home/node/node_modules

--- a/scripts/start-config-broker.sh
+++ b/scripts/start-config-broker.sh
@@ -151,7 +151,6 @@ case "${1:-}" in
   "applicationUnitOfMeasurement": "ha",
   "durationYears": 3,
   "payment": null,
-  "paymentMethod": null,
   "landCoverClassCodes": [],
   "rules": [],
   "sssiEligible": true,

--- a/src/features/grants-config/handlers/grants-config-update.handler.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.js
@@ -2,7 +2,8 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 
 /**
  * Process a single SQS message from the grants_config_broker_update queue.
- * Handles both SNS-wrapped messages (production) and raw messages (local testing).
+ * Messages are always SNS-wrapped (Type=Notification) with the manifest in body.Message
+ * and grant/status in body.MessageAttributes.
  * @param {import('@aws-sdk/client-sqs').Message} message - SQS message
  * @param {import('@aws-sdk/client-s3').S3Client} s3Client
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
@@ -18,20 +19,9 @@ async function processMessage(message, s3Client, db, logger, options) {
   }
 
   const body = JSON.parse(message.Body)
-
-  let manifest
-  let status
-  let grant
-
-  if (body.Type === 'Notification' && body.Message) {
-    manifest = JSON.parse(body.Message)
-    status = body.MessageAttributes?.status?.Value
-    grant = body.MessageAttributes?.grant?.Value
-  } else {
-    manifest = body.manifest ?? []
-    status = body.status
-    grant = body.grant
-  }
+  const manifest = JSON.parse(body.Message)
+  const status = body.MessageAttributes?.status?.Value
+  const grant = body.MessageAttributes?.grant?.Value
 
   if (grant !== 'land-grants') {
     logger.info(

--- a/src/features/grants-config/handlers/grants-config-update.handler.test.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.test.js
@@ -202,5 +202,4 @@ describe('processMessage', () => {
       )
     })
   })
-
 })

--- a/src/features/grants-config/handlers/grants-config-update.handler.test.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.test.js
@@ -21,7 +21,6 @@ function buildSnsMessage({
   return {
     MessageId: 'msg-1',
     Body: JSON.stringify({
-      Type: 'Notification',
       Message: JSON.stringify(manifest),
       MessageAttributes: {
         grant: { Type: 'String', Value: grant },
@@ -78,7 +77,6 @@ describe('processMessage', () => {
       const noGrantMessage = {
         MessageId: 'msg-no-grant',
         Body: JSON.stringify({
-          Type: 'Notification',
           Message: JSON.stringify([
             'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'
           ]),
@@ -205,54 +203,4 @@ describe('processMessage', () => {
     })
   })
 
-  describe('raw messages (local testing)', () => {
-    test('processes a raw message with grant, manifest and status fields', async () => {
-      const rawMessage = {
-        MessageId: 'msg-raw',
-        Body: JSON.stringify({
-          grant: 'land-grants',
-          manifest: ['land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'],
-          status: 'active'
-        })
-      }
-
-      await processMessage(
-        rawMessage,
-        mockS3Client,
-        mockDb,
-        mockLogger,
-        options
-      )
-
-      expect(processActionConfigFile).toHaveBeenCalledTimes(1)
-      expect(processActionConfigFile).toHaveBeenCalledWith(
-        mockLogger,
-        mockS3Client,
-        mockDb,
-        'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
-        'configs-bucket'
-      )
-    })
-
-    test('skips a raw message for a different grant', async () => {
-      const rawMessage = {
-        MessageId: 'msg-raw-other',
-        Body: JSON.stringify({
-          grant: 'example-grant-with-auth',
-          manifest: ['example-grant-with-auth/0.0.1/grants-ui/file1.txt'],
-          status: 'active'
-        })
-      }
-
-      await processMessage(
-        rawMessage,
-        mockS3Client,
-        mockDb,
-        mockLogger,
-        options
-      )
-
-      expect(processActionConfigFile).not.toHaveBeenCalled()
-    })
-  })
 })


### PR DESCRIPTION
Messages on the grants_config_broker_update queue are always SNS-wrapped,
so the if/else that branched on body.Type === 'Notification' was dead code.

The handler now unconditionally reads body.Message (the manifest) and
body.MessageAttributes (grant/status), matching the published SNS schema.