### PR TITLE
GSPS-412: Add start ingest endpoint

### DIFF
--- a/changelog/db.changelog-1.72.xml
+++ b/changelog/db.changelog-1.72.xml
@@ -13,21 +13,22 @@
       <column name="id" type="SERIAL" autoIncrement="true">
         <constraints primaryKey="true" nullable="false"/>
       </column>
-      <column name="metadata" type="JSONB"/>
-      <column name="start_date" type="DATE"/>
+      <column name="entity" type="TEXT"/>
+      <column name="status" type="TEXT"/>
+      <column name="start_date" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP"/>
       <column name="completed_date" type="DATE"/>
     </createTable>
    </changeSet>
 
-      <changeSet id="create-ingest-files-table" author="system">
+   <changeSet id="create-ingest-files-table" author="system">
      <createTable tableName="ingest_files" schemaName="public">
       <column name="id" type="SERIAL" autoIncrement="true">
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="ingest_id" type="INT"/>
-      <column name="resource_type" type="TEXT"/>
-      <column name="file_name" type="TEXT"/>
-      <column name="expected_rows" INT="NUMERIC"/>
+      <column name="filename" type="TEXT"/>
+      <column name="total_rows" type="NUMERIC"/>
+      <column name="status" type="TEXT"/>
     </createTable>
    </changeSet>
 

--- a/changelog/db.changelog-1.72.xml
+++ b/changelog/db.changelog-1.72.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+   <changeSet id="create-ingest-table" author="system">
+     <createTable tableName="ingest" schemaName="public">
+      <column name="id" type="SERIAL" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="metadata" type="JSONB"/>
+      <column name="start_date" type="DATE"/>
+      <column name="completed_date" type="DATE"/>
+    </createTable>
+   </changeSet>
+
+      <changeSet id="create-ingest-files-table" author="system">
+     <createTable tableName="ingest_files" schemaName="public">
+      <column name="id" type="SERIAL" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="ingest_id" type="INT"/>
+      <column name="resource_type" type="TEXT"/>
+      <column name="file_name" type="TEXT"/>
+      <column name="expected_rows" INT="NUMERIC"/>
+    </createTable>
+   </changeSet>
+
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -76,4 +76,5 @@
   <include  file="changelog/db.changelog-1.69.xml"/>
   <include  file="changelog/db.changelog-1.70.xml"/>
   <include  file="changelog/db.changelog-1.71.xml"/>
+  <include  file="changelog/db.changelog-1.72.xml"/>
 </databaseChangeLog>

--- a/scripts/ingest-land-data.js
+++ b/scripts/ingest-land-data.js
@@ -8,16 +8,16 @@ const environments = ['dev'] //, 'test', 'perf-test', 'ext-test'] // dev, test, 
 // The script expects folders named after each resource under scripts/ingestion-data/data/
 const resources = [
   'agreements',
-  'compatibility_matrix',
-  'moorland_designations',
-  'land_parcels',
-  'land_covers',
-  'sssi',
-  'registered_battlefields',
-  'shine',
-  'scheduled_monuments',
-  'registered_parks_gardens',
-  'action_sssi_hf_mapping'
+  // 'compatibility_matrix',
+  // 'moorland_designations',
+  // 'land_parcels',
+  // 'land_covers',
+  // 'sssi',
+  // 'registered_battlefields',
+  // 'shine',
+  // 'scheduled_monuments',
+  // 'registered_parks_gardens',
+  // 'action_sssi_hf_mapping'
 ]
 
 transferAllResources()

--- a/scripts/ingest-land-data.js
+++ b/scripts/ingest-land-data.js
@@ -7,17 +7,17 @@ const environments = ['dev'] //, 'test', 'perf-test', 'ext-test'] // dev, test, 
 
 // The script expects folders named after each resource under scripts/ingestion-data/data/
 const resources = [
-  'agreements'
-  // 'compatibility_matrix',
-  // 'moorland_designations',
-  // 'land_parcels',
-  // 'land_covers',
-  // 'sssi',
-  // 'registered_battlefields',
-  // 'shine',
-  // 'scheduled_monuments',
-  // 'registered_parks_gardens',
-  // 'action_sssi_hf_mapping'
+  'agreements',
+  'compatibility_matrix',
+  'moorland_designations',
+  'land_parcels',
+  'land_covers',
+  'sssi',
+  'registered_battlefields',
+  'shine',
+  'scheduled_monuments',
+  'registered_parks_gardens',
+  'action_sssi_hf_mapping'
 ]
 
 transferAllResources()

--- a/scripts/ingest-land-data.js
+++ b/scripts/ingest-land-data.js
@@ -7,7 +7,7 @@ const environments = ['dev'] //, 'test', 'perf-test', 'ext-test'] // dev, test, 
 
 // The script expects folders named after each resource under scripts/ingestion-data/data/
 const resources = [
-  'agreements',
+  'agreements'
   // 'compatibility_matrix',
   // 'moorland_designations',
   // 'land_parcels',

--- a/src/features/common/constants/entity_types.js
+++ b/src/features/common/constants/entity_types.js
@@ -1,0 +1,13 @@
+export const entityTypes = [
+  'agreements',
+  'compatibility_matrix',
+  'moorland_designations',
+  'land_parcels',
+  'land_covers',
+  'sssi',
+  'registered_battlefields',
+  'shine',
+  'scheduled_monuments',
+  'registered_parks_gardens',
+  'action_sssi_hf_mapping'
+]

--- a/src/features/land-data-ingest/controller/start-ingest.controller.js
+++ b/src/features/land-data-ingest/controller/start-ingest.controller.js
@@ -6,6 +6,7 @@ import {
 } from '../schema/start-ingest.schema.js'
 import { internalServerErrorResponseSchema } from '../../common/schema/index.js'
 import { saveIngestStart } from '../service/start-ingest.service.js'
+import { logBusinessError } from '../../common/helpers/logging/log-helpers.js'
 
 export const StartIngestController = {
   options: {
@@ -30,14 +31,15 @@ export const StartIngestController = {
    * @returns {Promise<import('@hapi/hapi').ResponseObject | import('@hapi/boom').Boom>} Validation response
    */
   handler: async (request, h) => {
+    const entity = request.params.entity
+    const {
+      logger,
+      // @ts-expect-error - postgresDb, payload
+      server: { postgresDb },
+      payload
+    } = request
+
     try {
-      const entity = request.params.entity
-      const {
-        logger,
-        // @ts-expect-error - postgresDb, payload
-        server: { postgresDb },
-        payload
-      } = request
       const ingestId = await saveIngestStart(
         // @ts-expect-error - payload
         payload,
@@ -50,6 +52,14 @@ export const StartIngestController = {
         ingestId
       })
     } catch (error) {
+      logBusinessError(logger, {
+        operation: 'start_ingest_endpoint',
+        context: {
+          entity,
+          payload
+        },
+        error
+      })
       return Boom.internal('Error starting land data ingest')
     }
   }

--- a/src/features/land-data-ingest/controller/start-ingest.controller.js
+++ b/src/features/land-data-ingest/controller/start-ingest.controller.js
@@ -1,0 +1,56 @@
+import Boom from '@hapi/boom'
+import {
+  startIngestParamsSchema,
+  startIngestRequestSchema,
+  startIngestResponseSchema
+} from '../schema/start-ingest.schema.js'
+import { internalServerErrorResponseSchema } from '../../common/schema/index.js'
+import { saveIngestStart } from '../service/start-ingest.service.js'
+
+export const StartIngestController = {
+  options: {
+    tags: ['api'],
+    description: 'Start land data ingest',
+    notes: 'land data ingest',
+    validate: {
+      payload: startIngestRequestSchema,
+      params: startIngestParamsSchema
+    },
+    response: {
+      status: {
+        200: startIngestResponseSchema,
+        500: internalServerErrorResponseSchema
+      }
+    }
+  },
+  /**
+   * Handler function for ingesting land data
+   * @param {import('@hapi/hapi').Request} request - Hapi request object
+   * @param {import('@hapi/hapi').ResponseToolkit} h - Hapi response toolkit
+   * @returns {Promise<import('@hapi/hapi').ResponseObject | import('@hapi/boom').Boom>} Validation response
+   */
+  handler: async (request, h) => {
+    try {
+      const entity = request.params.entity
+      const {
+        logger,
+        // @ts-expect-error - postgresDb, payload
+        server: { postgresDb },
+        payload
+      } = request
+      const ingestId = await saveIngestStart(
+        // @ts-expect-error - payload
+        payload,
+        entity,
+        postgresDb,
+        logger
+      )
+
+      return h.response({
+        ingestId
+      })
+    } catch (error) {
+      return Boom.internal('Error starting land data ingest')
+    }
+  }
+}

--- a/src/features/land-data-ingest/controller/start-ingest.controller.test.js
+++ b/src/features/land-data-ingest/controller/start-ingest.controller.test.js
@@ -1,0 +1,141 @@
+import createTestServer from '~/src/tests/test-server.js'
+import { StartIngestController } from './start-ingest.controller.js'
+import { saveIngestStart } from '../service/start-ingest.service.js'
+import { vi } from 'vitest'
+
+vi.mock('../service/start-ingest.service.js')
+
+describe('StartIngestController', () => {
+  const server = createTestServer()
+  const mockLogger = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn()
+  }
+
+  beforeAll(async () => {
+    server.decorate('request', 'logger', mockLogger)
+    server.decorate('server', 'postgresDb', {
+      query: vi.fn()
+    })
+
+    server.route({
+      method: 'POST',
+      path: '/ingest/{entity}/start',
+      handler: StartIngestController.handler,
+      options: StartIngestController.options
+    })
+
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('POST /ingest/{entity}/start', () => {
+    const validPayload = {
+      files: [
+        { filename: 'test_file_1.csv', row_count: 123 },
+        { filename: 'test_file_2.csv', row_count: 456 }
+      ]
+    }
+
+    test('should return 200 and the ingest_id when validation and saveIngestStart succeed', async () => {
+      saveIngestStart.mockResolvedValueOnce(999)
+
+      const request = {
+        method: 'POST',
+        url: '/ingest/agreements/start',
+        payload: validPayload
+      }
+
+      const { statusCode, result } = await server.inject(request)
+
+      expect(statusCode).toBe(200)
+      expect(result).toEqual({ ingest_id: 999 })
+      expect(saveIngestStart).toHaveBeenCalledWith(
+        validPayload,
+        'agreements',
+        server.postgresDb,
+        mockLogger
+      )
+    })
+
+    test('should return 400 when entity path param is invalid', async () => {
+      const request = {
+        method: 'POST',
+        url: '/ingest/invalid_entity_type/start',
+        payload: validPayload
+      }
+
+      const { statusCode } = await server.inject(request)
+
+      expect(statusCode).toBe(400)
+      expect(saveIngestStart).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when payload is missing required fields', async () => {
+      const request = {
+        method: 'POST',
+        url: '/ingest/agreements/start',
+        payload: {}
+      }
+
+      const { statusCode } = await server.inject(request)
+
+      expect(statusCode).toBe(400)
+      expect(saveIngestStart).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when filename in payload is missing', async () => {
+      const request = {
+        method: 'POST',
+        url: '/ingest/agreements/start',
+        payload: {
+          files: [{ row_count: 123 }]
+        }
+      }
+
+      const { statusCode } = await server.inject(request)
+
+      expect(statusCode).toBe(400)
+      expect(saveIngestStart).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when row_count in payload is missing', async () => {
+      const request = {
+        method: 'POST',
+        url: '/ingest/agreements/start',
+        payload: {
+          files: [{ filename: 'file.csv' }]
+        }
+      }
+
+      const { statusCode } = await server.inject(request)
+
+      expect(statusCode).toBe(400)
+      expect(saveIngestStart).not.toHaveBeenCalled()
+    })
+
+    test('should return 500 when saveIngestStart throws an error', async () => {
+      saveIngestStart.mockRejectedValueOnce(new Error('Database error'))
+
+      const request = {
+        method: 'POST',
+        url: '/ingest/agreements/start',
+        payload: validPayload
+      }
+
+      const { statusCode, result } = await server.inject(request)
+
+      expect(statusCode).toBe(500)
+      expect(result.message).toBe('An internal server error occurred')
+    })
+  })
+})

--- a/src/features/land-data-ingest/controller/start-ingest.controller.test.js
+++ b/src/features/land-data-ingest/controller/start-ingest.controller.test.js
@@ -41,8 +41,8 @@ describe('StartIngestController', () => {
   describe('POST /ingest/{entity}/start', () => {
     const validPayload = {
       files: [
-        { filename: 'test_file_1.csv', row_count: 123 },
-        { filename: 'test_file_2.csv', row_count: 456 }
+        { filename: 'test_file_1.csv', rows: 123 },
+        { filename: 'test_file_2.csv', rows: 456 }
       ]
     }
 
@@ -58,7 +58,7 @@ describe('StartIngestController', () => {
       const { statusCode, result } = await server.inject(request)
 
       expect(statusCode).toBe(200)
-      expect(result).toEqual({ ingest_id: 999 })
+      expect(result).toEqual({ ingestId: 999 })
       expect(saveIngestStart).toHaveBeenCalledWith(
         validPayload,
         'agreements',
@@ -98,7 +98,7 @@ describe('StartIngestController', () => {
         method: 'POST',
         url: '/ingest/agreements/start',
         payload: {
-          files: [{ row_count: 123 }]
+          files: [{ rows: 123 }]
         }
       }
 
@@ -108,7 +108,7 @@ describe('StartIngestController', () => {
       expect(saveIngestStart).not.toHaveBeenCalled()
     })
 
-    test('should return 400 when row_count in payload is missing', async () => {
+    test('should return 400 when rows in payload is missing', async () => {
       const request = {
         method: 'POST',
         url: '/ingest/agreements/start',

--- a/src/features/land-data-ingest/index.js
+++ b/src/features/land-data-ingest/index.js
@@ -1,6 +1,7 @@
 import { IngestController } from './controller/ingest.controller.js'
 import { LandDataIngestController } from './controller/land-data-ingest.controller.js'
 import { InitiateLandDataUploadController } from './controller/initiate-land-data-upload.controller.js'
+import { StartIngestController } from './controller/start-ingest.controller.js'
 
 /**
  * @satisfies {ServerRegisterPluginObject<void>}
@@ -34,6 +35,15 @@ const landDataIngest = {
           handler: IngestController.handler,
           options: {
             ...IngestController.options,
+            auth: false
+          }
+        },
+        {
+          method: 'POST',
+          path: '/ingest/{entity}/start',
+          handler: StartIngestController.handler,
+          options: {
+            ...StartIngestController.options,
             auth: false
           }
         }

--- a/src/features/land-data-ingest/schema/start-ingest.schema.js
+++ b/src/features/land-data-ingest/schema/start-ingest.schema.js
@@ -1,0 +1,21 @@
+import Joi from 'joi'
+import { entityTypes } from '../../common/constants/entity_types.js'
+
+const ingestFileSchema = Joi.object({
+  filename: Joi.string().required(),
+  rows: Joi.number().required()
+})
+
+export const startIngestRequestSchema = Joi.object({
+  files: Joi.array().items(ingestFileSchema).required()
+})
+
+export const startIngestParamsSchema = Joi.object({
+  entity: Joi.string()
+    .valid(...entityTypes)
+    .required()
+})
+
+export const startIngestResponseSchema = Joi.object({
+  ingestId: Joi.number().required()
+})

--- a/src/features/land-data-ingest/service/start-ingest.service.js
+++ b/src/features/land-data-ingest/service/start-ingest.service.js
@@ -1,0 +1,107 @@
+import {
+  logBusinessError,
+  logInfo
+} from '../../common/helpers/logging/log-helpers.js'
+
+/**
+ * Saves the ingest start data to the database
+ * @param {{files: Array<{ filename: string, rows: number }>}} data - Object containing files to ingest
+ * @param {string} entity - The entity to create an ingest for
+ * @param {import('pg').Client} dbClient - Database connection
+ * @param {object} logger - Logger instance
+ * @returns {Promise<object>} The ingest data
+ */
+export const saveIngestStart = async (data, entity, dbClient, logger) => {
+  try {
+    const { files } = data
+    const ingestId = await cancelAndCreateNewIngest(entity, dbClient, logger)
+
+    for (const file of files) {
+      const { filename, rows } = file
+
+      await dbClient.query(
+        `INSERT INTO ingest_files (ingest_id, filename, total_rows, status) VALUES ($1, $2, $3, $4)`,
+        [ingestId, filename, rows, 'pending']
+      )
+    }
+
+    await dropAndCreateNewStagingTable(entity, dbClient, logger)
+
+    return ingestId
+  } catch (error) {
+    logBusinessError(logger, {
+      operation: 'start_ingest',
+      context: {
+        entity,
+        data
+      },
+      error
+    })
+    throw error
+  }
+}
+
+/**
+ * Cancels existing in progress ingests and creates a new ingest record
+ * @param {string} entity - The entity to create an ingest for
+ * @param {import('pg').Client} dbClient - Database connection
+ * @param {object} logger - Logger instance
+ * @returns {Promise<object>} The ingest data
+ */
+export const cancelAndCreateNewIngest = async (entity, dbClient, logger) => {
+  // set in progress ingests to cancelled
+  const { rows } = await dbClient.query(
+    `UPDATE ingest SET status = 'cancelled' WHERE entity = $1 AND status = 'in_progress' RETURNING id`,
+    [entity]
+  )
+
+  if (rows.length > 0) {
+    logInfo(logger, {
+      category: 'ingest',
+      message: `Ingest tasks cancelled: ${rows.map((row) => row.id).join()}`,
+      context: {
+        ids: rows.map((row) => row.id),
+        entity
+      }
+    })
+  }
+
+  // insert new ingest
+  const {
+    rows: [ingest]
+  } = await dbClient.query(
+    `INSERT INTO ingest (entity, status) VALUES ($1, $2) RETURNING id`,
+    [entity, 'in_progress']
+  )
+
+  return ingest.id
+}
+
+/**
+ * Drops stagin table and creates a new staging table for the given entity
+ * @param {string} entity - The entity to create a staging table for
+ * @param {import('pg').Client} dbClient - Database connection
+ * @param {object} logger - Logger instance
+ * @returns {Promise<void>} Promise that resolves when the staging table is created
+ */
+export const dropAndCreateNewStagingTable = async (
+  entity,
+  dbClient,
+  logger
+) => {
+  const tblResult = await dbClient.query(
+    `SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = $1`,
+    [`${entity}_staging`]
+  )
+
+  if (tblResult.rows.length > 0) {
+    await dbClient.query(`DROP TABLE ${entity}_staging`)
+    logBusinessError(logger, {
+      operation: 'start_ingest',
+      context: `${entity}_staging`,
+      error: new Error('Staging table already exists')
+    })
+  }
+
+  await dbClient.query(`CREATE TABLE ${entity}_staging (LIKE ${entity})`)
+}

--- a/src/features/land-data-ingest/service/start-ingest.service.test.js
+++ b/src/features/land-data-ingest/service/start-ingest.service.test.js
@@ -130,8 +130,8 @@ describe('start ingest service', () => {
       const entity = 'test_entity'
       const data = {
         files: [
-          { filename: 'test_file_1', row_count: 123 },
-          { filename: 'test_file_2', row_count: 456 }
+          { filename: 'test_file_1', rows: 123 },
+          { filename: 'test_file_2', rows: 456 }
         ]
       }
       // UPDATE ingest (cancel in progress)

--- a/src/features/land-data-ingest/service/start-ingest.service.test.js
+++ b/src/features/land-data-ingest/service/start-ingest.service.test.js
@@ -1,0 +1,192 @@
+import {
+  dropAndCreateNewStagingTable,
+  cancelAndCreateNewIngest,
+  saveIngestStart
+} from './start-ingest.service.js'
+import {
+  logBusinessError,
+  logInfo
+} from '../../common/helpers/logging/log-helpers.js'
+
+vi.mock('../../common/helpers/logging/log-helpers.js', () => ({
+  logBusinessError: vi.fn(),
+  logInfo: vi.fn()
+}))
+
+describe('start ingest service', () => {
+  let dbClient
+  let logger
+
+  beforeEach(() => {
+    dbClient = {
+      query: vi.fn()
+    }
+    logger = {
+      info: vi.fn(),
+      error: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('cancelAndCreateNewIngest', () => {
+    test('should create new ingest', async () => {
+      const entity = 'test_entity'
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ id: 123 }]
+      })
+
+      const result = await cancelAndCreateNewIngest(entity, dbClient, logger)
+
+      expect(result).toEqual(123)
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `UPDATE ingest SET status = 'cancelled' WHERE entity = $1 AND status = 'in_progress' RETURNING id`,
+        [entity]
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `INSERT INTO ingest (entity, status) VALUES ($1, $2) RETURNING id`,
+        [entity, 'in_progress']
+      )
+    })
+
+    test('should cancel in progress ingests and create new ingest', async () => {
+      const entity = 'test_entity'
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ id: 123 }]
+      })
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ id: 456 }]
+      })
+
+      const result = await cancelAndCreateNewIngest(entity, dbClient, logger)
+
+      expect(result).toEqual(456)
+      expect(logInfo).toHaveBeenCalledWith(logger, {
+        category: 'ingest',
+        message: `Ingest tasks cancelled: 123`,
+        context: {
+          ids: [123],
+          entity
+        }
+      })
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `UPDATE ingest SET status = 'cancelled' WHERE entity = $1 AND status = 'in_progress' RETURNING id`,
+        [entity]
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `INSERT INTO ingest (entity, status) VALUES ($1, $2) RETURNING id`,
+        [entity, 'in_progress']
+      )
+    })
+  })
+
+  describe('dropAndCreateNewStagingTable', () => {
+    test('should create a new staging table', async () => {
+      const entity = 'test_entity'
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+      await dropAndCreateNewStagingTable(entity, dbClient, logger)
+
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = $1`,
+        [`${entity}_staging`]
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `CREATE TABLE ${entity}_staging (LIKE ${entity})`
+      )
+    })
+
+    test('should drop the staging table if it exists', async () => {
+      const entity = 'test_entity'
+
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ tablename: `${entity}_staging` }]
+      })
+
+      await dropAndCreateNewStagingTable(entity, dbClient, logger)
+
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `DROP TABLE ${entity}_staging`
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `CREATE TABLE ${entity}_staging (LIKE ${entity})`
+      )
+      expect(logBusinessError).toHaveBeenCalledWith(logger, {
+        operation: 'start_ingest',
+        context: `${entity}_staging`,
+        error: new Error('Staging table already exists')
+      })
+    })
+  })
+
+  describe('saveIngestStart', () => {
+    test('should save ingest start data to the database', async () => {
+      const entity = 'test_entity'
+      const data = {
+        files: [
+          { filename: 'test_file_1', row_count: 123 },
+          { filename: 'test_file_2', row_count: 456 }
+        ]
+      }
+      // UPDATE ingest (cancel in progress)
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ id: 123 }]
+      })
+      // INSERT ingest
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ id: 456 }]
+      })
+      // INSERT ingest_files (file 1)
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+      // INSERT ingest_files (file 2)
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+      // SELECT pg_tables (staging table exists)
+      dbClient.query.mockResolvedValueOnce({
+        rows: [{ tablename: `${entity}_staging` }]
+      })
+      // DROP TABLE staging
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+      // CREATE TABLE staging
+      dbClient.query.mockResolvedValueOnce({
+        rows: []
+      })
+
+      await saveIngestStart(data, entity, dbClient, logger)
+
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `INSERT INTO ingest (entity, status) VALUES ($1, $2) RETURNING id`,
+        [entity, 'in_progress']
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `INSERT INTO ingest_files (ingest_id, filename, total_rows, status) VALUES ($1, $2, $3, $4)`,
+        [456, 'test_file_1', 123, 'pending']
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `INSERT INTO ingest_files (ingest_id, filename, total_rows, status) VALUES ($1, $2, $3, $4)`,
+        [456, 'test_file_2', 456, 'pending']
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = $1`,
+        [`${entity}_staging`]
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `DROP TABLE ${entity}_staging`
+      )
+      expect(dbClient.query).toHaveBeenCalledWith(
+        `CREATE TABLE ${entity}_staging (LIKE ${entity})`
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new /ingest/{entity}/start endpoint

- creates a new ingest record and cancel any current ingest
- saves expected ingest files and counts
- drops and creates the staging table