### PR TITLE
GSPS-353 debug the remote grants-config-broker integration

### DIFF
--- a/src/features/grants-config/handlers/grants-config-update.handler.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.js
@@ -2,8 +2,9 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 
 /**
  * Process a single SQS message from the grants_config_broker_update queue.
- * Messages are always SNS-wrapped (Type=Notification) with the manifest in body.Message
- * and grant/status in body.MessageAttributes.
+ * Supports two delivery formats:
+ *  - SNS-wrapped (standard delivery): body is a notification envelope with Message + MessageAttributes
+ *  - Raw delivery: body is the manifest array directly; attributes are on message.MessageAttributes
  * @param {import('@aws-sdk/client-sqs').Message} message - SQS message
  * @param {import('@aws-sdk/client-s3').S3Client} s3Client
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
@@ -14,30 +15,42 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 async function processMessage(message, s3Client, db, logger, options) {
   const { grantsConfigBucket } = options
 
-  logger.info({
-    msg: 'Received SQS grants-config-broker message',
-    message: JSON.parse(JSON.stringify(message, null, 2))
-  })
+  logger.info(
+    `Received SQS grants-config-broker message: ${JSON.stringify(message, null, 2)}`
+  )
 
   if (!message.Body) {
     throw new Error(`SQS message ${message.MessageId} has no body`)
   }
 
   const body = JSON.parse(message.Body)
-  const manifest = JSON.parse(body.Message)
-  const status = body.MessageAttributes?.status?.Value
-  const grant = body.MessageAttributes?.grant?.Value
+
+  let manifest, grant, status, version
+
+  if (Array.isArray(body)) {
+    // Raw delivery: body is the manifest array; attributes are on the SQS message envelope
+    manifest = body
+    grant = message.MessageAttributes?.grant?.StringValue
+    status = message.MessageAttributes?.status?.StringValue
+    version = message.MessageAttributes?.version?.StringValue
+  } else {
+    // SNS-wrapped delivery: body is the notification envelope
+    manifest = JSON.parse(body.Message)
+    grant = body.MessageAttributes?.grant?.Value
+    status = body.MessageAttributes?.status?.Value
+    version = body.MessageAttributes?.version?.Value
+  }
 
   if (grant !== 'land-grants') {
     logger.info(
-      `Skipping grants-config message for grant="${grant}" (only "land-grants" is processed)`
+      `Skipping grants-config message for grant="${grant}" version="${version}" (only "land-grants" is processed)`
     )
     return
   }
 
   if (status !== 'active') {
     logger.info(
-      `Skipping grants-config message with status="${status}" (only "active" is processed)`
+      `Skipping grants-config message with status="${status}" grant="${grant}" version="${version}" (only "active" is processed)`
     )
     return
   }
@@ -45,9 +58,15 @@ async function processMessage(message, s3Client, db, logger, options) {
   const actionKeys = manifest.filter((key) => key.includes('/actions/'))
 
   if (actionKeys.length === 0) {
-    logger.info('No action config files found in manifest — nothing to process')
+    logger.info(
+      `No action config files found in manifest for grant="${grant}" version="${version}" — nothing to process`
+    )
     return
   }
+
+  logger.info(
+    `Processing grants-config for grant="${grant}" version="${version}" (${actionKeys.length} action file(s))`
+  )
 
   for (const key of actionKeys) {
     await processActionConfigFile(logger, s3Client, db, key, grantsConfigBucket)

--- a/src/features/grants-config/handlers/grants-config-update.handler.test.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.test.js
@@ -5,8 +5,8 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 vi.mock('~/src/features/grants-config/service/grants-config.service.js')
 
 /**
- * Builds an SNS-wrapped SQS message body matching the shape produced by
- * grants-config-broker's publishMessage(manifest, { grant, path, version, status }).
+ * Builds an SNS-wrapped SQS message (standard SNS delivery, no RawMessageDelivery).
+ * Body is the SNS notification envelope; attributes use { Type, Value } shape.
  */
 function buildSnsMessage({
   grant = 'land-grants',
@@ -29,6 +29,32 @@ function buildSnsMessage({
         path: { Type: 'String', Value: path }
       }
     })
+  }
+}
+
+/**
+ * Builds a raw-delivery SQS message (RawMessageDelivery=true on the SNS subscription).
+ * Body is the manifest array directly; attributes are on the SQS envelope with { DataType, StringValue }.
+ */
+function buildDirectMessage({
+  grant = 'land-grants',
+  version = '1.2.3',
+  status = 'active',
+  path = 'cdp-grants-config-broker-dev',
+  manifest = [
+    'land-grants/1.2.3/actions/PA3/pa3-2.0.0.json',
+    'land-grants/1.2.3/metadata.json'
+  ]
+} = {}) {
+  return {
+    MessageId: 'msg-direct-1',
+    Body: JSON.stringify(manifest),
+    MessageAttributes: {
+      grant: { DataType: 'String', StringValue: grant },
+      version: { DataType: 'String', StringValue: version },
+      status: { DataType: 'String', StringValue: status },
+      path: { DataType: 'String', StringValue: path }
+    }
   }
 }
 
@@ -201,5 +227,97 @@ describe('processMessage', () => {
         expect.stringContaining('No action config files found')
       )
     })
+  })
+})
+
+describe('processMessage — raw SQS delivery (RawMessageDelivery=true)', () => {
+  let mockLogger
+  let mockS3Client
+  let mockDb
+  const options = { grantsConfigBucket: 'configs-bucket' }
+
+  beforeEach(() => {
+    mockLogger = { info: vi.fn(), error: vi.fn() }
+    mockS3Client = {}
+    mockDb = {}
+    processActionConfigFile.mockResolvedValue(undefined)
+  })
+
+  test('processes an action file from a direct message', async () => {
+    await processMessage(
+      buildDirectMessage(),
+      mockS3Client,
+      mockDb,
+      mockLogger,
+      options
+    )
+
+    expect(processActionConfigFile).toHaveBeenCalledTimes(1)
+    expect(processActionConfigFile).toHaveBeenCalledWith(
+      mockLogger,
+      mockS3Client,
+      mockDb,
+      'land-grants/1.2.3/actions/PA3/pa3-2.0.0.json',
+      'configs-bucket'
+    )
+  })
+
+  test('logs the version from message attributes', async () => {
+    await processMessage(
+      buildDirectMessage({ version: '1.2.3' }),
+      mockS3Client,
+      mockDb,
+      mockLogger,
+      options
+    )
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('version="1.2.3"')
+    )
+  })
+
+  test('skips a message for a different grant', async () => {
+    await processMessage(
+      buildDirectMessage({ grant: 'other-grant' }),
+      mockS3Client,
+      mockDb,
+      mockLogger,
+      options
+    )
+
+    expect(processActionConfigFile).not.toHaveBeenCalled()
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('grant="other-grant"')
+    )
+  })
+
+  test('skips a message with status "draft"', async () => {
+    await processMessage(
+      buildDirectMessage({ status: 'draft' }),
+      mockS3Client,
+      mockDb,
+      mockLogger,
+      options
+    )
+
+    expect(processActionConfigFile).not.toHaveBeenCalled()
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('status="draft"')
+    )
+  })
+
+  test('does nothing when the manifest has no action files', async () => {
+    await processMessage(
+      buildDirectMessage({ manifest: ['land-grants/1.2.3/metadata.json'] }),
+      mockS3Client,
+      mockDb,
+      mockLogger,
+      options
+    )
+
+    expect(processActionConfigFile).not.toHaveBeenCalled()
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('No action config files found')
+    )
   })
 })


### PR DESCRIPTION
The logging of the SNS -> SQS message was not being logged correctly, so that was fixed.

Additionally, `start-floci.sh` creates the SNS subscription without --attributes `RawMessageDelivery=true`, so locally the body arrives SNS-wrapped and .Value works.

Remotely the subscription uses raw delivery, body is the manifest array directly, and attributes use .StringValue — which the old code didn't handle.

If this is the case, then I will have to configure our floci setup to mimic the remote SNS/SQS environments.