### PR TITLE
GSPS-353: handle SNS raw delivery format and log version

### DIFF
--- a/scripts/infra/start-floci.sh
+++ b/scripts/infra/start-floci.sh
@@ -28,9 +28,10 @@ echo "Creating grants-config-broker SNS topic"
 aws sns create-topic --name gfr__sns___config_update
 echo "Created SNS topic: gfr__sns___config_update"
 
-echo "Subscribing SQS queue to SNS topic"
+echo "Subscribing SQS queue to SNS topic (raw delivery)"
 aws sns subscribe \
   --topic-arn arn:aws:sns:${AWS_REGION}:000000000000:gfr__sns___config_update \
   --protocol sqs \
+  --attributes RawMessageDelivery=true \
   --notification-endpoint arn:aws:sqs:${AWS_REGION}:000000000000:grants_config_broker_update
 echo "Subscribed grants_config_broker_update to gfr__sns___config_update"

--- a/src/features/grants-config/handlers/grants-config-update.handler.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.js
@@ -2,9 +2,7 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 
 /**
  * Process a single SQS message from the grants_config_broker_update queue.
- * Supports two delivery formats:
- *  - SNS-wrapped (standard delivery): body is a notification envelope with Message + MessageAttributes
- *  - Raw delivery: body is the manifest array directly; attributes are on message.MessageAttributes
+ * Messages arrive via SNS raw delivery: body is the manifest array, attributes on message.MessageAttributes.
  * @param {import('@aws-sdk/client-sqs').Message} message - SQS message
  * @param {import('@aws-sdk/client-s3').S3Client} s3Client
  * @param {import('~/src/features/common/postgres.d.js').Pool} db
@@ -23,23 +21,10 @@ async function processMessage(message, s3Client, db, logger, options) {
     throw new Error(`SQS message ${message.MessageId} has no body`)
   }
 
-  const body = JSON.parse(message.Body)
-
-  let manifest, grant, status, version
-
-  if (Array.isArray(body)) {
-    // Raw delivery: body is the manifest array; attributes are on the SQS message envelope
-    manifest = body
-    grant = message.MessageAttributes?.grant?.StringValue
-    status = message.MessageAttributes?.status?.StringValue
-    version = message.MessageAttributes?.version?.StringValue
-  } else {
-    // SNS-wrapped delivery: body is the notification envelope
-    manifest = JSON.parse(body.Message)
-    grant = body.MessageAttributes?.grant?.Value
-    status = body.MessageAttributes?.status?.Value
-    version = body.MessageAttributes?.version?.Value
-  }
+  const manifest = JSON.parse(message.Body)
+  const grant = message.MessageAttributes?.grant?.StringValue
+  const status = message.MessageAttributes?.status?.StringValue
+  const version = message.MessageAttributes?.version?.StringValue
 
   if (grant !== 'land-grants') {
     logger.info(

--- a/src/features/grants-config/handlers/grants-config-update.handler.test.js
+++ b/src/features/grants-config/handlers/grants-config-update.handler.test.js
@@ -4,50 +4,18 @@ import { processActionConfigFile } from '~/src/features/grants-config/service/gr
 
 vi.mock('~/src/features/grants-config/service/grants-config.service.js')
 
-/**
- * Builds an SNS-wrapped SQS message (standard SNS delivery, no RawMessageDelivery).
- * Body is the SNS notification envelope; attributes use { Type, Value } shape.
- */
-function buildSnsMessage({
+function buildMessage({
   grant = 'land-grants',
-  version = '0.0.2',
+  version = '0.1.1',
   status = 'active',
-  path = 's3://grants-config',
+  path = 'dev-grants-config-c63f2',
   manifest = [
-    'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
-    'land-grants/0.0.2/metadata.json'
+    'land-grants/0.1.1/actions/PA3/pa3-1.0.0.json',
+    'land-grants/0.1.1/metadata.json'
   ]
 } = {}) {
   return {
     MessageId: 'msg-1',
-    Body: JSON.stringify({
-      Message: JSON.stringify(manifest),
-      MessageAttributes: {
-        grant: { Type: 'String', Value: grant },
-        version: { Type: 'String', Value: version },
-        status: { Type: 'String', Value: status },
-        path: { Type: 'String', Value: path }
-      }
-    })
-  }
-}
-
-/**
- * Builds a raw-delivery SQS message (RawMessageDelivery=true on the SNS subscription).
- * Body is the manifest array directly; attributes are on the SQS envelope with { DataType, StringValue }.
- */
-function buildDirectMessage({
-  grant = 'land-grants',
-  version = '1.2.3',
-  status = 'active',
-  path = 'cdp-grants-config-broker-dev',
-  manifest = [
-    'land-grants/1.2.3/actions/PA3/pa3-2.0.0.json',
-    'land-grants/1.2.3/metadata.json'
-  ]
-} = {}) {
-  return {
-    MessageId: 'msg-direct-1',
     Body: JSON.stringify(manifest),
     MessageAttributes: {
       grant: { DataType: 'String', StringValue: grant },
@@ -74,7 +42,7 @@ describe('processMessage', () => {
   describe('grant filtering', () => {
     test('processes a message for grant "land-grants"', async () => {
       await processMessage(
-        buildSnsMessage(),
+        buildMessage(),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -86,7 +54,7 @@ describe('processMessage', () => {
 
     test('skips a message for a different grant', async () => {
       await processMessage(
-        buildSnsMessage({ grant: 'example-grant-with-auth', status: 'active' }),
+        buildMessage({ grant: 'example-grant-with-auth' }),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -102,14 +70,10 @@ describe('processMessage', () => {
     test('skips a message when grant attribute is absent', async () => {
       const noGrantMessage = {
         MessageId: 'msg-no-grant',
-        Body: JSON.stringify({
-          Message: JSON.stringify([
-            'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json'
-          ]),
-          MessageAttributes: {
-            status: { Type: 'String', Value: 'active' }
-          }
-        })
+        Body: JSON.stringify(['land-grants/0.1.1/actions/PA3/pa3-1.0.0.json']),
+        MessageAttributes: {
+          status: { DataType: 'String', StringValue: 'active' }
+        }
       }
 
       await processMessage(
@@ -130,7 +94,7 @@ describe('processMessage', () => {
   describe('status filtering', () => {
     test('processes a message with status "active"', async () => {
       await processMessage(
-        buildSnsMessage({ status: 'active' }),
+        buildMessage({ status: 'active' }),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -142,7 +106,7 @@ describe('processMessage', () => {
 
     test('skips a message with status "draft"', async () => {
       await processMessage(
-        buildSnsMessage({ status: 'draft' }),
+        buildMessage({ status: 'draft' }),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -157,7 +121,7 @@ describe('processMessage', () => {
 
     test('skips a message with status "none"', async () => {
       await processMessage(
-        buildSnsMessage({ status: 'none' }),
+        buildMessage({ status: 'none' }),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -171,7 +135,7 @@ describe('processMessage', () => {
   describe('manifest processing', () => {
     test('processes only action config files from the manifest', async () => {
       await processMessage(
-        buildSnsMessage(),
+        buildMessage(),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -183,14 +147,14 @@ describe('processMessage', () => {
         mockLogger,
         mockS3Client,
         mockDb,
-        'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
+        'land-grants/0.1.1/actions/PA3/pa3-1.0.0.json',
         'configs-bucket'
       )
     })
 
     test('skips non-action files in the manifest', async () => {
       await processMessage(
-        buildSnsMessage(),
+        buildMessage(),
         mockS3Client,
         mockDb,
         mockLogger,
@@ -198,15 +162,15 @@ describe('processMessage', () => {
       )
 
       const calledKeys = processActionConfigFile.mock.calls.map((c) => c[3])
-      expect(calledKeys).not.toContain('land-grants/0.0.2/metadata.json')
+      expect(calledKeys).not.toContain('land-grants/0.1.1/metadata.json')
     })
 
     test('processes multiple action files in the manifest', async () => {
-      const message = buildSnsMessage({
+      const message = buildMessage({
         manifest: [
-          'land-grants/0.0.2/actions/PA3/pa3-1.0.0.json',
-          'land-grants/0.0.2/actions/CSAM3/csam3-1.0.0.json',
-          'land-grants/0.0.2/metadata.json'
+          'land-grants/0.1.1/actions/PA3/pa3-1.0.0.json',
+          'land-grants/0.1.1/actions/CSAM3/csam3-1.0.0.json',
+          'land-grants/0.1.1/metadata.json'
         ]
       })
 
@@ -216,8 +180,8 @@ describe('processMessage', () => {
     })
 
     test('does nothing when the manifest has no action files', async () => {
-      const message = buildSnsMessage({
-        manifest: ['land-grants/0.0.2/metadata.json']
+      const message = buildMessage({
+        manifest: ['land-grants/0.1.1/metadata.json']
       })
 
       await processMessage(message, mockS3Client, mockDb, mockLogger, options)
@@ -227,97 +191,19 @@ describe('processMessage', () => {
         expect.stringContaining('No action config files found')
       )
     })
-  })
-})
 
-describe('processMessage — raw SQS delivery (RawMessageDelivery=true)', () => {
-  let mockLogger
-  let mockS3Client
-  let mockDb
-  const options = { grantsConfigBucket: 'configs-bucket' }
+    test('logs the version from message attributes', async () => {
+      await processMessage(
+        buildMessage({ version: '0.1.1' }),
+        mockS3Client,
+        mockDb,
+        mockLogger,
+        options
+      )
 
-  beforeEach(() => {
-    mockLogger = { info: vi.fn(), error: vi.fn() }
-    mockS3Client = {}
-    mockDb = {}
-    processActionConfigFile.mockResolvedValue(undefined)
-  })
-
-  test('processes an action file from a direct message', async () => {
-    await processMessage(
-      buildDirectMessage(),
-      mockS3Client,
-      mockDb,
-      mockLogger,
-      options
-    )
-
-    expect(processActionConfigFile).toHaveBeenCalledTimes(1)
-    expect(processActionConfigFile).toHaveBeenCalledWith(
-      mockLogger,
-      mockS3Client,
-      mockDb,
-      'land-grants/1.2.3/actions/PA3/pa3-2.0.0.json',
-      'configs-bucket'
-    )
-  })
-
-  test('logs the version from message attributes', async () => {
-    await processMessage(
-      buildDirectMessage({ version: '1.2.3' }),
-      mockS3Client,
-      mockDb,
-      mockLogger,
-      options
-    )
-
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      expect.stringContaining('version="1.2.3"')
-    )
-  })
-
-  test('skips a message for a different grant', async () => {
-    await processMessage(
-      buildDirectMessage({ grant: 'other-grant' }),
-      mockS3Client,
-      mockDb,
-      mockLogger,
-      options
-    )
-
-    expect(processActionConfigFile).not.toHaveBeenCalled()
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      expect.stringContaining('grant="other-grant"')
-    )
-  })
-
-  test('skips a message with status "draft"', async () => {
-    await processMessage(
-      buildDirectMessage({ status: 'draft' }),
-      mockS3Client,
-      mockDb,
-      mockLogger,
-      options
-    )
-
-    expect(processActionConfigFile).not.toHaveBeenCalled()
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      expect.stringContaining('status="draft"')
-    )
-  })
-
-  test('does nothing when the manifest has no action files', async () => {
-    await processMessage(
-      buildDirectMessage({ manifest: ['land-grants/1.2.3/metadata.json'] }),
-      mockS3Client,
-      mockDb,
-      mockLogger,
-      options
-    )
-
-    expect(processActionConfigFile).not.toHaveBeenCalled()
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      expect.stringContaining('No action config files found')
-    )
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('version="0.1.1"')
+      )
+    })
   })
 })


### PR DESCRIPTION
The remote environment delivers grants-config-broker messages via SNS with RawMessageDelivery=true, meaning the SQS message body is the manifest array directly and attributes sit on message.MessageAttributes with StringValue — not wrapped in an SNS notification envelope.

The handler was only reading the SNS-wrapped format (body.Message + body.MessageAttributes.*.Value), which caused silent failures remotely while local tests passed because they mocked the wrapped format.

 - Add RawMessageDelivery=true to the floci SNS subscription so local mirrors remote exactly
 - Simplify handler to a single code path using message.MessageAttributes and StringValue
 - Extract and log version alongside grant and status in all log lines
 - Log the full raw SQS message on receipt for easier debugging
 - Update tests to use the real DataType/StringValue attribute shape