### PR TITLE
 GSPS-430 Allow calculate and validate to accept per-action config versions

### DIFF
--- a/src/features/actions/service/action.service.js
+++ b/src/features/actions/service/action.service.js
@@ -17,7 +17,8 @@ const getActions = async (request, postgresDb, landActions, applicationId) => {
   const flattenedLandActions =
     landActions?.flatMap((landAction) =>
       landAction.actions.map((action) => ({
-        code: action.code
+        code: action.code,
+        version: action.version
       }))
     ) ?? []
 
@@ -49,14 +50,16 @@ const getActions = async (request, postgresDb, landActions, applicationId) => {
     context: { previousRunActions }
   })
 
-  // merge actions, deduplicating by code and preferring versioned entries from previous runs
+  // merge actions: caller-supplied version > prior-run version > latest
   const actionMap = new Map(
     flattenedLandActions.map((action) => [action.code, action])
   )
 
-  // deduplicate the actions by code
   for (const action of previousRunActions) {
-    actionMap.set(action.code, action)
+    const existing = actionMap.get(action.code)
+    if (existing && !existing.version) {
+      actionMap.set(action.code, action)
+    }
   }
   const mergedActions = [...actionMap.values()]
 

--- a/src/features/actions/service/action.service.js
+++ b/src/features/actions/service/action.service.js
@@ -4,8 +4,9 @@ import { getActionsByVersion } from '~/src/features/actions/queries/2.0.0/getAct
 
 /**
  * Get all action configs for the given land actions, pinning versions from any previous validation run.
- * Actions present in a prior run are fetched at their previously-used version; new actions are fetched
- * at their latest version.
+ * Actions present in a prior run are fetched at their previously-used version, taking priority over any
+ * caller-supplied version for that action; actions not present in a prior run use the caller-supplied
+ * version if given, otherwise the latest version.
  * @param {import('@hapi/hapi').Request} request - Hapi request object
  * @param {object} postgresDb - The postgres database instance
  * @param {Array} landActions - The land actions from the request payload
@@ -50,16 +51,13 @@ const getActions = async (request, postgresDb, landActions, applicationId) => {
     context: { previousRunActions }
   })
 
-  // merge actions: caller-supplied version > prior-run version > latest
+  // merge actions: prior-run version (pinned to applicationId) > caller-supplied version > latest
   const actionMap = new Map(
     flattenedLandActions.map((action) => [action.code, action])
   )
 
   for (const action of previousRunActions) {
-    const existing = actionMap.get(action.code)
-    if (existing && !existing.version) {
-      actionMap.set(action.code, action)
-    }
+    actionMap.set(action.code, action)
   }
   const mergedActions = [...actionMap.values()]
 

--- a/src/features/actions/service/action.service.test.js
+++ b/src/features/actions/service/action.service.test.js
@@ -255,7 +255,7 @@ describe('Action Service', () => {
       })
     })
 
-    test('should use caller-supplied version over prior-run version', async () => {
+    test('should ignore caller-supplied version in favour of the version pinned to applicationId', async () => {
       mockGetLatestApplicationRunForAppId.mockResolvedValue({
         data: {
           parcelLevelResults: [
@@ -284,7 +284,7 @@ describe('Action Service', () => {
       const calledWith = mockGetActionsByVersion.mock.calls[0][2]
       expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
         code: 'CMOR1',
-        version: '3.0.0'
+        version: '1.0.0'
       })
     })
 
@@ -321,7 +321,7 @@ describe('Action Service', () => {
       })
     })
 
-    test('should apply caller versions and prior-run versions independently per action', async () => {
+    test('should apply pinned and caller versions independently per action', async () => {
       mockGetLatestApplicationRunForAppId.mockResolvedValue({
         data: {
           parcelLevelResults: [
@@ -355,14 +355,17 @@ describe('Action Service', () => {
       )
 
       const calledWith = mockGetActionsByVersion.mock.calls[0][2]
+      // CMOR1: pinned to applicationId, so the caller-supplied version is ignored
       expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
         code: 'CMOR1',
-        version: '3.0.0'
+        version: '1.0.0'
       })
+      // CMOR2: pinned to applicationId, caller supplied no version
       expect(calledWith.find((a) => a.code === 'CMOR2')).toMatchObject({
         code: 'CMOR2',
         version: '1.5.0'
       })
+      // CMOR3: not pinned, caller-supplied version applies
       expect(calledWith.find((a) => a.code === 'CMOR3')).toMatchObject({
         code: 'CMOR3',
         version: '2.0.0'

--- a/src/features/actions/service/action.service.test.js
+++ b/src/features/actions/service/action.service.test.js
@@ -226,5 +226,147 @@ describe('Action Service', () => {
 
       expect(result).toEqual([])
     })
+
+    test('should use caller-supplied version when no prior run exists', async () => {
+      mockGetLatestApplicationRunForAppId.mockResolvedValue(null)
+
+      const landActionsWithVersions = [
+        {
+          sheetId: 'SX0679',
+          parcelId: '9238',
+          actions: [
+            { code: 'CMOR1', quantity: 5, version: '2.1.0' },
+            { code: 'CMOR2', quantity: 3 }
+          ]
+        }
+      ]
+
+      await getActions(
+        mockRequest,
+        mockPostgresDb,
+        landActionsWithVersions,
+        mockApplicationId
+      )
+
+      const calledWith = mockGetActionsByVersion.mock.calls[0][2]
+      expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
+        code: 'CMOR1',
+        version: '2.1.0'
+      })
+    })
+
+    test('should use caller-supplied version over prior-run version', async () => {
+      mockGetLatestApplicationRunForAppId.mockResolvedValue({
+        data: {
+          parcelLevelResults: [
+            {
+              actions: [{ code: 'CMOR1', actionConfigVersion: '1.0.0' }]
+            }
+          ]
+        }
+      })
+
+      const landActionsWithCallerVersion = [
+        {
+          sheetId: 'SX0679',
+          parcelId: '9238',
+          actions: [{ code: 'CMOR1', quantity: 5, version: '3.0.0' }]
+        }
+      ]
+
+      await getActions(
+        mockRequest,
+        mockPostgresDb,
+        landActionsWithCallerVersion,
+        mockApplicationId
+      )
+
+      const calledWith = mockGetActionsByVersion.mock.calls[0][2]
+      expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
+        code: 'CMOR1',
+        version: '3.0.0'
+      })
+    })
+
+    test('should fall back to prior-run version when caller omits version', async () => {
+      mockGetLatestApplicationRunForAppId.mockResolvedValue({
+        data: {
+          parcelLevelResults: [
+            {
+              actions: [{ code: 'CMOR1', actionConfigVersion: '1.5.0' }]
+            }
+          ]
+        }
+      })
+
+      const landActionsWithoutVersion = [
+        {
+          sheetId: 'SX0679',
+          parcelId: '9238',
+          actions: [{ code: 'CMOR1', quantity: 5 }]
+        }
+      ]
+
+      await getActions(
+        mockRequest,
+        mockPostgresDb,
+        landActionsWithoutVersion,
+        mockApplicationId
+      )
+
+      const calledWith = mockGetActionsByVersion.mock.calls[0][2]
+      expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
+        code: 'CMOR1',
+        version: '1.5.0'
+      })
+    })
+
+    test('should apply caller versions and prior-run versions independently per action', async () => {
+      mockGetLatestApplicationRunForAppId.mockResolvedValue({
+        data: {
+          parcelLevelResults: [
+            {
+              actions: [
+                { code: 'CMOR1', actionConfigVersion: '1.0.0' },
+                { code: 'CMOR2', actionConfigVersion: '1.5.0' }
+              ]
+            }
+          ]
+        }
+      })
+
+      const landActionsWithMixedVersions = [
+        {
+          sheetId: 'SX0679',
+          parcelId: '9238',
+          actions: [
+            { code: 'CMOR1', quantity: 5, version: '3.0.0' },
+            { code: 'CMOR2', quantity: 3 },
+            { code: 'CMOR3', quantity: 2, version: '2.0.0' }
+          ]
+        }
+      ]
+
+      await getActions(
+        mockRequest,
+        mockPostgresDb,
+        landActionsWithMixedVersions,
+        mockApplicationId
+      )
+
+      const calledWith = mockGetActionsByVersion.mock.calls[0][2]
+      expect(calledWith.find((a) => a.code === 'CMOR1')).toMatchObject({
+        code: 'CMOR1',
+        version: '3.0.0'
+      })
+      expect(calledWith.find((a) => a.code === 'CMOR2')).toMatchObject({
+        code: 'CMOR2',
+        version: '1.5.0'
+      })
+      expect(calledWith.find((a) => a.code === 'CMOR3')).toMatchObject({
+        code: 'CMOR3',
+        version: '2.0.0'
+      })
+    })
   })
 })

--- a/src/features/application/schema/application-validation.schema.js
+++ b/src/features/application/schema/application-validation.schema.js
@@ -14,7 +14,8 @@ const applicationValidationSchema = Joi.object({
           .items(
             Joi.object({
               code: Joi.string().required(),
-              quantity: Joi.number().positive().required()
+              quantity: Joi.number().positive().required(),
+              version: Joi.string().optional()
             })
           )
           .required()

--- a/src/features/application/schema/application-validation.schema.test.js
+++ b/src/features/application/schema/application-validation.schema.test.js
@@ -140,6 +140,55 @@ describe('Application Validation Schema', () => {
       const { error } = applicationValidationSchema.validate(data)
       expect(error).toBeUndefined()
     })
+
+    it('should accept an action with an optional version string', () => {
+      const data = {
+        ...validData,
+        landActions: [
+          {
+            sheetId: 'sheet-1',
+            parcelId: 'parcel-1',
+            actions: [{ code: 'ACTION1', quantity: 10, version: '2.1.0' }]
+          }
+        ]
+      }
+      const { error } = applicationValidationSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('should accept actions where some have version and some do not', () => {
+      const data = {
+        ...validData,
+        landActions: [
+          {
+            sheetId: 'sheet-1',
+            parcelId: 'parcel-1',
+            actions: [
+              { code: 'ACTION1', quantity: 10, version: '2.1.0' },
+              { code: 'ACTION2', quantity: 5 }
+            ]
+          }
+        ]
+      }
+      const { error } = applicationValidationSchema.validate(data)
+      expect(error).toBeUndefined()
+    })
+
+    it('should reject a non-string action version', () => {
+      const data = {
+        ...validData,
+        landActions: [
+          {
+            sheetId: 'sheet-1',
+            parcelId: 'parcel-1',
+            actions: [{ code: 'ACTION1', quantity: 10, version: 123 }]
+          }
+        ]
+      }
+      const { error } = applicationValidationSchema.validate(data)
+      expect(error).toBeDefined()
+      expect(error.details[0].message).toContain('version')
+    })
   })
 
   describe('applicationValidationRunSchema', () => {

--- a/src/features/payment/schema/2.0.0/payment-calculate.schema.js
+++ b/src/features/payment/schema/2.0.0/payment-calculate.schema.js
@@ -37,7 +37,8 @@ const PaymentCalculateSchema = Joi.object({
           .items(
             Joi.object({
               code: Joi.string().required(),
-              quantity: Joi.number().positive().required()
+              quantity: Joi.number().positive().required(),
+              version: Joi.string().optional()
             })
           )
           .required()

--- a/src/features/payment/schema/2.0.0/payment-calculate.schema.test.js
+++ b/src/features/payment/schema/2.0.0/payment-calculate.schema.test.js
@@ -1,4 +1,106 @@
-import { PaymentCalculateResponseSchemaV2 } from './payment-calculate.schema.js'
+import {
+  PaymentCalculateSchema,
+  PaymentCalculateResponseSchemaV2
+} from './payment-calculate.schema.js'
+
+describe('PaymentCalculateSchema (request)', () => {
+  const validRequest = {
+    parcel: [
+      {
+        sheetId: 'SD2324',
+        parcelId: '1253',
+        actions: [{ code: 'CSAM1', quantity: 10.5 }]
+      }
+    ]
+  }
+
+  it('should accept a valid request', () => {
+    const { error } = PaymentCalculateSchema.validate(validRequest)
+    expect(error).toBeUndefined()
+  })
+
+  it('should accept an action with an optional version string', () => {
+    const data = {
+      parcel: [
+        {
+          sheetId: 'SD2324',
+          parcelId: '1253',
+          actions: [{ code: 'CSAM1', quantity: 10.5, version: '2.1.0' }]
+        }
+      ]
+    }
+    const { error } = PaymentCalculateSchema.validate(data)
+    expect(error).toBeUndefined()
+  })
+
+  it('should accept actions where some have version and some do not', () => {
+    const data = {
+      parcel: [
+        {
+          sheetId: 'SD2324',
+          parcelId: '1253',
+          actions: [
+            { code: 'CSAM1', quantity: 10.5, version: '2.1.0' },
+            { code: 'CMOR1', quantity: 5 }
+          ]
+        }
+      ]
+    }
+    const { error } = PaymentCalculateSchema.validate(data)
+    expect(error).toBeUndefined()
+  })
+
+  it('should reject a non-string action version', () => {
+    const data = {
+      parcel: [
+        {
+          sheetId: 'SD2324',
+          parcelId: '1253',
+          actions: [{ code: 'CSAM1', quantity: 10.5, version: 123 }]
+        }
+      ]
+    }
+    const { error } = PaymentCalculateSchema.validate(data)
+    expect(error).toBeDefined()
+    expect(error.details[0].message).toContain('version')
+  })
+
+  it('should require parcel array', () => {
+    const { error } = PaymentCalculateSchema.validate({})
+    expect(error).toBeDefined()
+    expect(error.details[0].message).toContain('parcel')
+  })
+
+  it('should require action code', () => {
+    const data = {
+      parcel: [
+        {
+          sheetId: 'SD2324',
+          parcelId: '1253',
+          actions: [{ quantity: 10.5 }]
+        }
+      ]
+    }
+    const { error } = PaymentCalculateSchema.validate(data)
+    expect(error).toBeDefined()
+    expect(error.details[0].message).toContain('code')
+  })
+
+  it('should require positive action quantity', () => {
+    const data = {
+      parcel: [
+        {
+          sheetId: 'SD2324',
+          parcelId: '1253',
+          actions: [{ code: 'CSAM1', quantity: -1 }]
+        }
+      ]
+    }
+    const { error } = PaymentCalculateSchema.validate(data)
+    expect(error).toBeDefined()
+    expect(error.details[0].message).toContain('quantity')
+  })
+})
 
 describe('Payment Calculate Schema Validation V2', () => {
   describe('PaymentCalculateResponseSchemaV2', () => {


### PR DESCRIPTION
Add an optional version field to each action item in the calculate and validate
request payloads so callers can pin to a specific major.minor config version.