### PR TITLE
GSPS-411: pre-create land_parcels_staging and land_covers_staging via Liquibase

### DIFF
--- a/changelog/db.changelog-1.76.xml
+++ b/changelog/db.changelog-1.76.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+  <changeSet id="create-land-parcels-staging-table" author="system">
+    <sql>CREATE TABLE IF NOT EXISTS land_parcels_staging (LIKE land_parcels INCLUDING ALL);</sql>
+  </changeSet>
+
+  <changeSet id="create-land-covers-staging-table" author="system">
+    <sql>CREATE TABLE IF NOT EXISTS land_covers_staging (LIKE land_covers INCLUDING ALL);</sql>
+  </changeSet>
+
+  <changeSet id="grant-permissions-for-land-parcels-staging" author="system">
+    <sql>GRANT select, insert, truncate on land_parcels_staging to land_grants_api;</sql>
+  </changeSet>
+
+  <changeSet id="grant-permissions-for-land-covers-staging" author="system">
+    <sql>GRANT select, insert, truncate on land_covers_staging to land_grants_api;</sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -80,4 +80,5 @@
   <include  file="changelog/db.changelog-1.73.xml"/>
   <include  file="changelog/db.changelog-1.74.xml"/>
   <include  file="changelog/db.changelog-1.75.xml"/>
+  <include  file="changelog/db.changelog-1.76.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Create permanent staging tables owned by the Liquibase migration user, granting land_grants_api select, insert and truncate. 

This avoids requiring CREATE ON SCHEMA public at runtime.