### PR TITLE
GSPS-415 emit metrics for unlinked parcels and covers

### DIFF
--- a/src/features/common/plugins/statistics.js
+++ b/src/features/common/plugins/statistics.js
@@ -5,6 +5,7 @@ import {
   stopStatsCache,
   refreshCachedStats
 } from '~/src/features/statistics/stats-cache.js'
+import { metricsCounter } from '~/src/features/common/helpers/metrics.js'
 
 export const statistics = {
   plugin: {
@@ -23,6 +24,17 @@ export const statistics = {
             message: 'Get stats',
             context: stats
           })
+          const { unlinkedParcelsCount, unlinkedCoversCount } =
+            /** @type {{ unlinkedParcelsCount: string | number, unlinkedCoversCount: string | number }} */ (
+              stats
+            )
+          await Promise.all([
+            metricsCounter(
+              'unlinked_parcels_count',
+              Number(unlinkedParcelsCount)
+            ),
+            metricsCounter('unlinked_covers_count', Number(unlinkedCoversCount))
+          ])
         }
 
         server.logger.info('Statistics cron job completed successfully')

--- a/src/features/common/plugins/statistics.test.js
+++ b/src/features/common/plugins/statistics.test.js
@@ -5,12 +5,14 @@ const {
   mockSchedule,
   mockInitStatsCache,
   mockStopStatsCache,
-  mockRefreshCachedStats
+  mockRefreshCachedStats,
+  mockMetricsCounter
 } = vi.hoisted(() => ({
   mockSchedule: vi.fn(),
   mockInitStatsCache: vi.fn(),
   mockStopStatsCache: vi.fn(),
-  mockRefreshCachedStats: vi.fn()
+  mockRefreshCachedStats: vi.fn(),
+  mockMetricsCounter: vi.fn()
 }))
 
 vi.mock('node-cron', () => ({
@@ -23,6 +25,10 @@ vi.mock('~/src/features/statistics/stats-cache.js', () => ({
   initStatsCache: mockInitStatsCache,
   stopStatsCache: mockStopStatsCache,
   refreshCachedStats: mockRefreshCachedStats
+}))
+
+vi.mock('~/src/features/common/helpers/metrics.js', () => ({
+  metricsCounter: mockMetricsCounter
 }))
 
 describe('#statistics', () => {
@@ -164,5 +170,31 @@ describe('#statistics', () => {
     stopHandler()
 
     expect(mockStopStatsCache).toHaveBeenCalledTimes(1)
+  })
+
+  test('Should emit unlinked_parcels_count and unlinked_covers_count metrics when stats are available', async () => {
+    await statistics.plugin.register(mockServer)
+
+    const cronCallback = mockSchedule.mock.calls[0][1]
+    mockRefreshCachedStats.mockResolvedValue({
+      unlinkedParcelsCount: 5,
+      unlinkedCoversCount: 3
+    })
+
+    await cronCallback()
+
+    expect(mockMetricsCounter).toHaveBeenCalledWith('unlinked_parcels_count', 5)
+    expect(mockMetricsCounter).toHaveBeenCalledWith('unlinked_covers_count', 3)
+  })
+
+  test('Should not emit orphan metrics when stats refresh returns undefined', async () => {
+    await statistics.plugin.register(mockServer)
+
+    const cronCallback = mockSchedule.mock.calls[0][1]
+    mockRefreshCachedStats.mockResolvedValue(undefined)
+
+    await cronCallback()
+
+    expect(mockMetricsCounter).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
The statistics cron already calculates the **unlinkedParcelsCount** and
**unlinkedCoversCount** every 30 minutes.