### PR TITLE
fix:return ingest completed

### DIFF
--- a/src/features/land-data-ingest/schema/status.schema.js
+++ b/src/features/land-data-ingest/schema/status.schema.js
@@ -18,7 +18,7 @@ export const statusIngestResponseSchema = Joi.object({
   entity: Joi.string().required(),
   status: Joi.string().required(),
   start_date: Joi.date().required(),
-  completed_date: Joi.string().allow(null).optional(),
+  completed_date: Joi.date().allow(null).optional(),
   files: Joi.array().items(statusFileResponseSchema).optional()
 })
 

--- a/src/tests/e2e-tests/ingestion.e2e.test.js
+++ b/src/tests/e2e-tests/ingestion.e2e.test.js
@@ -122,7 +122,7 @@ describe('Ingestion Endpoints', () => {
     })
   })
 
-  describe('POST /ingest/{entity}/start', async () => {
+  describe('POST /ingest/{entity}/start', () => {
     test('should return new ingestId for valid payload', async () => {
       const response = await httpClient.post('/ingest/land_parcels/start', {
         headers: { Authorization: getAuthHeader() },

--- a/src/tests/e2e-tests/ingestion.e2e.test.js
+++ b/src/tests/e2e-tests/ingestion.e2e.test.js
@@ -121,4 +121,49 @@ describe('Ingestion Endpoints', () => {
       expect(response.data).toHaveProperty('message')
     })
   })
+
+  describe('POST /ingest/{entity}/start', async () => {
+    test('should return new ingestId for valid payload', async () => {
+      const response = await httpClient.post('/ingest/land_parcels/start', {
+        headers: { Authorization: getAuthHeader() },
+        body: {
+          files: [
+            {
+              filename: 'land-data.csv',
+              rows: 10
+            }
+          ]
+        }
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data).toHaveProperty('ingestId')
+    })
+
+    test('should return status for ingestId', async () => {
+      const response = await httpClient.post('/ingest/land_parcels/start', {
+        headers: { Authorization: getAuthHeader() },
+        body: {
+          files: [
+            {
+              filename: 'land-data.csv',
+              rows: 10
+            }
+          ]
+        }
+      })
+
+      const { ingestId } = response.data
+
+      const statusResponse = await httpClient.get(
+        `/ingest/status?ingestId=${ingestId}`,
+        {
+          headers: { Authorization: getAuthHeader() }
+        }
+      )
+
+      expect(statusResponse.status).toBe(200)
+      expect(statusResponse.data).toHaveProperty('status')
+    })
+  })
 })


### PR DESCRIPTION
fixes an error in the return payload for the /ingest/status call, where completed_date should be a date type.