### PR TITLE
Revert "enable auth for ingest endpoints (#717)"

### DIFF
--- a/src/features/land-data-ingest/index.js
+++ b/src/features/land-data-ingest/index.js
@@ -16,7 +16,8 @@ const landDataIngest = {
           path: '/initiate-upload',
           handler: InitiateLandDataUploadController.handler,
           options: {
-            ...InitiateLandDataUploadController.options
+            ...InitiateLandDataUploadController.options,
+            auth: false
           }
         },
         {
@@ -33,7 +34,8 @@ const landDataIngest = {
           path: '/ingest/{entity}/start',
           handler: StartIngestController.handler,
           options: {
-            ...StartIngestController.options
+            ...StartIngestController.options,
+            auth: false
           }
         },
         {
@@ -41,7 +43,8 @@ const landDataIngest = {
           path: '/ingest/status',
           handler: StatusIngestController.handler,
           options: {
-            ...StatusIngestController.options
+            ...StatusIngestController.options,
+            auth: false
           }
         }
       ])

--- a/src/tests/e2e-tests/ingestion.e2e.test.js
+++ b/src/tests/e2e-tests/ingestion.e2e.test.js
@@ -1,12 +1,10 @@
 import { describe, test, expect } from 'vitest'
 import { httpClient } from './setup/http-client.js'
-import { getAuthHeader } from './setup/auth-helpers.js'
 
 describe('Ingestion Endpoints', () => {
   describe('POST /initiate-upload', () => {
     test('should return 200 with upload URL for valid payload', async () => {
       const response = await httpClient.post('/initiate-upload', {
-        headers: { Authorization: getAuthHeader() },
         body: {
           reference: 'REF-e2e-1',
           customerId: 'CUST-e2e-1',
@@ -22,7 +20,6 @@ describe('Ingestion Endpoints', () => {
 
     test('should return 400 for missing required fields', async () => {
       const response = await httpClient.post('/initiate-upload', {
-        headers: { Authorization: getAuthHeader() },
         body: {
           reference: 'REF-e2e-2'
         }
@@ -33,7 +30,6 @@ describe('Ingestion Endpoints', () => {
 
     test('should return 400 for invalid resource', async () => {
       const response = await httpClient.post('/initiate-upload', {
-        headers: { Authorization: getAuthHeader() },
         body: {
           reference: 'REF-e2e-3',
           customerId: 'CUST-e2e-3',

--- a/src/tests/e2e-tests/ingestion.e2e.test.js
+++ b/src/tests/e2e-tests/ingestion.e2e.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { httpClient } from './setup/http-client.js'
+import { getAuthHeader } from './setup/auth-helpers.js'
 
 describe('Ingestion Endpoints', () => {
   describe('POST /initiate-upload', () => {


### PR DESCRIPTION
Reverts #717.

This restores the ingest endpoints (`/initiate-upload`, `/ingest/{entity}/start`, `/ingest/status`) to `auth: false` and removes the `Authorization` headers added to the ingestion e2e tests.

Reverts commit dd9529f69474eb151d84af39711993c068785935.