### PR TITLE
GSPS-459 - added rounding to pence conversions

### DIFF
--- a/src/features/common/helpers/currency.js
+++ b/src/features/common/helpers/currency.js
@@ -1,0 +1,6 @@
+/**
+ * Converts a GBP amount to pence, rounding to the nearest integer.
+ * @param {number} gbp
+ * @returns {number}
+ */
+export const gbpToPence = (gbp = 0) => Math.round(gbp * 100)

--- a/src/features/common/helpers/currency.test.js
+++ b/src/features/common/helpers/currency.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { gbpToPence } from './currency.js'
+
+describe('gbpToPence', () => {
+  it('should convert pounds into pence', () => {
+    expect(gbpToPence(20)).toBe(2000)
+  })
+
+  it('should round to the nearest integer pence', () => {
+    expect(gbpToPence(10.001)).toBe(1000)
+    expect(gbpToPence(10.007)).toBe(1001)
+  })
+
+  it('should handle undefined with default parameter', () => {
+    expect(gbpToPence()).toBe(0)
+    expect(gbpToPence(undefined)).toBe(0)
+  })
+})

--- a/src/features/payment-calculation/amountCalculation.js
+++ b/src/features/payment-calculation/amountCalculation.js
@@ -1,5 +1,6 @@
 import { differenceInCalendarMonths } from 'date-fns'
 import { createExplanationSection } from '~/src/features/available-area/explanations.js'
+import { gbpToPence } from '~/src/features/common/helpers/currency.js'
 
 /**
  * currency formatter
@@ -10,13 +11,6 @@ const currencyFormatter = new Intl.NumberFormat('en-GB', {
   style: 'currency',
   currency: 'GBP'
 })
-
-/**
- * Gbp to pence
- * @param {number} gbp
- * @returns {number}
- */
-export const gbpToPence = (gbp = 0) => gbp * 100
 
 /**
  * Find an action by code

--- a/src/features/payment-calculation/amountCalculation.test.js
+++ b/src/features/payment-calculation/amountCalculation.test.js
@@ -4,7 +4,6 @@ import {
   calculateScheduledPayments,
   createPaymentItems,
   findActionByCode,
-  gbpToPence,
   reconcilePaymentAmounts,
   roundPaymentAmountForPaymentLineItems
 } from './amountCalculation.js'
@@ -1331,15 +1330,6 @@ describe('addAgreementItem', () => {
 })
 
 describe('helper methods', () => {
-  it('gbpToPence should convert pounds into pence', () => {
-    expect(gbpToPence(20)).toBe(2000)
-  })
-
-  it('gbpToPence should handle undefined with default parameter', () => {
-    expect(gbpToPence()).toBe(0)
-    expect(gbpToPence(undefined)).toBe(0)
-  })
-
   it('findActionByCode should return the found action', () => {
     const foundAction = { code: 'CMOR1' }
     const actions = [foundAction]

--- a/src/features/woodland-management/transformer/wmp-payment-calculate.transformer.js
+++ b/src/features/woodland-management/transformer/wmp-payment-calculate.transformer.js
@@ -7,15 +7,9 @@ import {
   startOfMonth
 } from 'date-fns'
 import { roundTo4DecimalPlaces } from '../../common/helpers/measurement.js'
+import { gbpToPence } from '../../common/helpers/currency.js'
 
 const DATE_FORMAT = 'yyyy-MM-dd'
-
-/**
- * Converts a GBP amount to pence.
- * @param {number} gbp - The amount in GBP
- * @returns {number} The amount in pence
- */
-const gbpToPence = (gbp) => gbp * 100
 
 /**
  * Returns the agreement start date. When `startDate` is provided it is used as

--- a/src/features/woodland-management/transformer/wmp-payment-calculate.transformer.test.js
+++ b/src/features/woodland-management/transformer/wmp-payment-calculate.transformer.test.js
@@ -104,6 +104,48 @@ describe('transformAgreementLevelItems', () => {
   })
 })
 
+describe('pence rounding', () => {
+  test('transformPayments produces integer pence when payment GBP has sub-cent precision', () => {
+    const result = transformPayments({
+      ...createWmpCalculationResult(),
+      payment: 10.001
+    })
+    expect(Number.isInteger(result[0].totalPaymentPence)).toBe(true)
+    expect(Number.isInteger(result[0].lineItems[0].paymentPence)).toBe(true)
+    expect(result[0].totalPaymentPence).toBe(1000)
+  })
+
+  test('transformAgreementLevelItems produces integer pence for all pence fields', () => {
+    const result = transformAgreementLevelItems(
+      ['SX067-99238'],
+      createAction(),
+      {
+        ...createWmpCalculationResult(),
+        payment: 10.001,
+        activeTierRatePence: 30.005,
+        activeTierFlatRatePence: 15.007
+      }
+    )
+    expect(Number.isInteger(result[1].agreementTotalPence)).toBe(true)
+    expect(Number.isInteger(result[1].activeTierRatePence)).toBe(true)
+    expect(Number.isInteger(result[1].activeTierFlatRatePence)).toBe(true)
+    expect(result[1].agreementTotalPence).toBe(1000)
+    expect(result[1].activeTierRatePence).toBe(3001)
+    expect(result[1].activeTierFlatRatePence).toBe(1501)
+  })
+
+  test('wmpPaymentCalculateTransformer produces integer agreementTotalPence', () => {
+    const result = wmpPaymentCalculateTransformer(
+      ['SX067-99238'],
+      { ...createWmpCalculationResult(), payment: 10.001 },
+      createAction(),
+      '2024-01-01'
+    )
+    expect(Number.isInteger(result.agreementTotalPence)).toBe(true)
+    expect(result.agreementTotalPence).toBe(1000)
+  })
+})
+
 describe('wmpPaymentCalculateTransformer', () => {
   test('should return the full response shape with a fixed startDate', () => {
     const result = wmpPaymentCalculateTransformer(


### PR DESCRIPTION
There has been an incident where a decimal pence value caused an agreement to fail for WMP. This tightens up the GBP to pence conversion