### PR TITLE
GSPS-447: Fetch agreements from DAL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,7 @@ CLIENT_SECRET_PROD=xxx
 AUTH_HEADER_TOKEN=xxx
 
 ENABLE_TEST_ENDPOINTS=true
+
+# DAL/Existing agreements
+USE_DAL_AGREEMENTS=true
+DAL_API_ENDPOINT=http://localhost:3001/graphql

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+lint:
+	npm run lint
+	npm run lint:types
+	npm run format:check
+
+lint-fix:
+	npm run lint:fix
+	npm run format
+
+test:
+	npm run test:quick

--- a/README.md
+++ b/README.md
@@ -303,6 +303,14 @@ npm run test:ingest
 npm run test:e2e
 ```
 
+To run an individual test, you can use:
+
+```bash
+npx vitest run --config=vitest.unit.config.js [test file]
+```
+
+You can also filter tests by tags or description; see vitest docs for more details.
+
 ## Database Migrations
 
 The api uses [Liquibase](https://docs.liquibase.com/home.html) for db migrations, the `changelog` folder contains our current `postgres` schema.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -321,6 +321,14 @@ const config = convict({
       default: 'x-cdp-request-id',
       env: 'TRACING_HEADER'
     }
+  },
+  dal: {
+    apiEndpoint: {
+      doc: 'DAL GraphQL endpoint',
+      format: String,
+      default: '',
+      env: 'DAL_API_ENDPOINT'
+    }
   }
 })
 

--- a/src/features/agreements/transformers/agreements.transformer.js
+++ b/src/features/agreements/transformers/agreements.transformer.js
@@ -1,9 +1,20 @@
+import { haToSqm } from '~/src/features/common/helpers/measurement.js'
+
+const DAL_QUANTITY_UNITS = {
+  actionArea: 'sqm',
+  actionMTL: 'm',
+  actionUnits: 'count'
+}
+const DAL_QUANTITY_KEYS = ['actionArea', 'actionMTL', 'actionUnits']
+
+const STATUS_SIGNED = 'SIGNED'
+
 /**
  * Transforms actions from DB format to AgreementAction format.
  * @param {object[]} agreements - The agreements to transform.
  * @returns {AgreementAction[]} The transformed agreement actions.
  */
-function agreementActionsTransformer(agreements) {
+export function agreementActionsTransformer(agreements) {
   if (!agreements || agreements.length === 0) {
     return []
   }
@@ -25,12 +36,69 @@ function agreementActionsTransformer(agreements) {
  * @param {AgreementAction[]} plannedActions
  * @returns {AgreementAction[]}
  */
-function mergeAgreementsTransformer(agreementActions, plannedActions) {
+export function mergeAgreementsTransformer(agreementActions, plannedActions) {
   return [...(agreementActions || []), ...(plannedActions || [])]
 }
 
-export { agreementActionsTransformer, mergeAgreementsTransformer }
+/**
+ * Extract quantity and unit fields from a DAL GraphQL representation of an agreement action
+ *
+ * The quantity will be present in one of three fields, actionArea / actionMTL / actionUnits, and
+ * the other two will be absent. Unit information isn't provided but will always be hectares for
+ * areas, metres for length, and count for countable items (like trees or tractors)
+ *
+ * Additionally, we'll convert hectares into sqm to avoid passing around floating point numbers
+ * @param {import("../../../services/dal/business.d.js").AgreementAction} action The DAL action from which to extract data
+ * @returns {object}
+ */
+function getDalQuantityFields(action) {
+  let key = null
+  DAL_QUANTITY_KEYS.forEach((k) => {
+    const v = action[k]
+    if (v !== undefined && v !== null) {
+      key = k
+    }
+  })
+
+  if (key === null) {
+    return { quantity: null, units: null }
+  }
+
+  const quantity = key === 'actionArea' ? haToSqm(action[key]) : action[key]
+  const unit = DAL_QUANTITY_UNITS[key]
+
+  return { quantity, unit }
+}
+
+/**
+ * Convert Business instance received from DAL to an array of internal AgreementActions
+ * @param {Business} business The business to convert
+ * @returns {AgreementAction[]} Agreements related to this business
+ */
+export function dalBusinessToAgreements(business, parcelId, sheetId) {
+  // Agreement actions are nested in agreement.paymentSchedules so we flatten them out of the
+  // agreements array. We also need to filter by agreement status and parcelId + sheetId in order
+  // to limit results to relevant ones.
+  return (
+    (business?.agreements || [])
+      .filter((agreement) => agreement.status === STATUS_SIGNED)
+      .flatMap((agreement) => agreement.paymentSchedules)
+      .filter(
+        (action) =>
+          action.parcelName === parcelId && action.sheetName === sheetId
+      )
+      .map((a) => ({
+        actionCode: a.optionCode,
+        startDate: new Date(a.startDate),
+        endDate: new Date(a.endDate),
+        ...getDalQuantityFields(a)
+      }))
+      // Capital actions will have no quantity at all, we'll also filter these out
+      .filter((a) => a.quantity !== null)
+  )
+}
 
 /**
  * @import { AgreementAction } from "../agreements.d.js"
+ * @import { Business } from "../../../services/dal/business.d.js"
  */

--- a/src/features/agreements/transformers/agreements.transformer.test.js
+++ b/src/features/agreements/transformers/agreements.transformer.test.js
@@ -1,7 +1,14 @@
+import * as fx from '~/src/services/dal/fixtures/business.js'
 import {
   agreementActionsTransformer,
+  dalBusinessToAgreements,
   mergeAgreementsTransformer
 } from './agreements.transformer.js'
+
+const defaultDates = {
+  startDate: new Date('2020-01-01T00:00:00+01:00'),
+  endDate: new Date('2021-01-01T00:00:00+01:00')
+}
 
 describe('agreementActionsTransformer', () => {
   test('should transform agreements with actions correctly', () => {
@@ -384,5 +391,115 @@ describe('mergeAgreementsTransformer', () => {
         unit: 'm'
       }
     ])
+  })
+})
+
+describe('dalBusinessToAgreements', () => {
+  test('should transform a business actions to AgreementActions', () => {
+    const expected = [
+      {
+        actionCode: 'BN1',
+        quantity: 10,
+        unit: 'm',
+        ...defaultDates
+      },
+      {
+        actionCode: 'BN2',
+        quantity: 10,
+        unit: 'm',
+        ...defaultDates
+      },
+      {
+        actionCode: 'AF1',
+        quantity: 1000,
+        unit: 'count',
+        ...defaultDates
+      }
+    ]
+    const actual = dalBusinessToAgreements(
+      fx.SIMPLE_BUSINESS,
+      fx.PARCEL_ID,
+      fx.SHEET_ID
+    )
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('should transform hectare areas into sqm', () => {
+    const expected = [
+      {
+        actionCode: 'CLIG3',
+        quantity: 1000000,
+        unit: 'sqm',
+        ...defaultDates
+      }
+    ]
+    const actual = dalBusinessToAgreements(
+      fx.BUSINESS_CLIG3,
+      fx.PARCEL_ID,
+      fx.SHEET_ID
+    )
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('should filter out non-SIGNED agreements', () => {
+    const expected = [
+      {
+        actionCode: 'AF1',
+        quantity: 1000,
+        unit: 'count',
+        ...defaultDates
+      }
+    ]
+    const actual = dalBusinessToAgreements(
+      fx.BUSINESS_WITH_DRAFTS,
+      fx.PARCEL_ID,
+      fx.SHEET_ID
+    )
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('should filter resulting actions by parcelId and sheetName', () => {
+    const expected = [
+      {
+        actionCode: 'BN1',
+        quantity: 10,
+        unit: 'm',
+        ...defaultDates
+      }
+    ]
+    const actual = dalBusinessToAgreements(
+      fx.BUSINESS_WITH_MULTIPLE_PARCELS,
+      fx.PARCEL_ID,
+      fx.SHEET_ID
+    )
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('should filter out actions with capital grants (no quantity specified at all)', () => {
+    const expected = [
+      {
+        actionCode: 'BN1',
+        quantity: 10,
+        unit: 'm',
+        ...defaultDates
+      },
+      {
+        actionCode: 'AF1',
+        quantity: 1000,
+        unit: 'count',
+        ...defaultDates
+      }
+    ]
+    const actual = dalBusinessToAgreements(
+      fx.BUSINESS_WITH_CAPITAL_GRANTS,
+      fx.PARCEL_ID,
+      fx.SHEET_ID
+    )
+
+    expect(actual).toEqual(expected)
   })
 })

--- a/src/services/dal/business.d.js
+++ b/src/services/dal/business.d.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {object} AgreementAction
+ * @property {string} optionCode - The action code
+ * @property {string} sheetName - Sheet name for this action
+ * @property {string} parcelName - Parcel ID for this action
+ * @property {number} [actionArea] - Area for this action, in hectares, if area-based
+ * @property {number} [actionMTL] - Length for this action, in metres, if length-based
+ * @property {number} [actionUnits] - Count for this action, if count-based
+ * @property {string} startDate - Start date for this action, ISO 8601
+ * @property {string} endDate - Start date for this action, ISO 8601
+ */
+
+/**
+ * @typedef {object} Agreement
+ * @property {string} status - The status of this agreement, e.g. "SIGNED", "DRAFT", "ADMIN CHECK"
+ * @property {AgreementAction[]} paymentSchedules - Actions under this agreement
+ */
+
+/**
+ * @typedef {object} Business
+ * @property {Agreement[]} agreements - Agreements for this business
+ */

--- a/src/services/dal/fixtures/business.js
+++ b/src/services/dal/fixtures/business.js
@@ -1,0 +1,85 @@
+export const PARCEL_ID = '0001'
+export const SHEET_ID = 'NY0001'
+
+const ACTION_COMMON = {
+  parcelName: PARCEL_ID,
+  sheetName: SHEET_ID,
+  startDate: '2020-01-01T00:00:00+01:00',
+  endDate: '2021-01-01T00:00:00+01:00'
+}
+
+// Repair stone-faced earth banks, paid per metre
+const ACTION_BN1 = {
+  actionArea: null,
+  actionMTL: 10,
+  actionUnits: null,
+  optionCode: 'BN1',
+  ...ACTION_COMMON
+}
+
+const ACTION_BN2 = { ...ACTION_BN1, optionCode: 'BN2' }
+
+// Construct wetlands to treat pollution (capital grant, paid as 50% of actual cost)
+const ACTION_RP8 = {
+  actionArea: null,
+  actionMTL: null,
+  actionUnits: null,
+  optionCode: 'RP8',
+  ...ACTION_COMMON
+}
+
+// Manage grassland, paid per hectare
+const ACTION_CLIG3 = {
+  actionArea: 100,
+  actionMTL: null,
+  actionUnits: null,
+  optionCode: 'CLIG3',
+  ...ACTION_COMMON
+}
+
+// Plant trees, paid per tree
+const ACTION_AF1 = {
+  actionArea: null,
+  actionMTL: null,
+  actionUnits: 1000,
+  optionCode: 'AF1',
+  ...ACTION_COMMON
+}
+
+export const SIMPLE_BUSINESS = {
+  agreements: [
+    { status: 'SIGNED', paymentSchedules: [ACTION_BN1, ACTION_BN2] },
+    { status: 'SIGNED', paymentSchedules: [ACTION_AF1] }
+  ]
+}
+
+export const BUSINESS_CLIG3 = {
+  agreements: [{ status: 'SIGNED', paymentSchedules: [ACTION_CLIG3] }]
+}
+
+export const BUSINESS_WITH_DRAFTS = {
+  agreements: [
+    { status: 'DRAFT', paymentSchedules: [ACTION_BN1] },
+    { status: 'DRAFT', paymentSchedules: [ACTION_BN2] },
+    { status: 'SIGNED', paymentSchedules: [ACTION_AF1] }
+  ]
+}
+
+export const BUSINESS_WITH_CAPITAL_GRANTS = {
+  agreements: [
+    { status: 'SIGNED', paymentSchedules: [ACTION_BN1, ACTION_AF1, ACTION_RP8] }
+  ]
+}
+
+export const BUSINESS_WITH_MULTIPLE_PARCELS = {
+  agreements: [
+    {
+      status: 'SIGNED',
+      paymentSchedules: [
+        ACTION_BN1,
+        { ...ACTION_BN2, parcelName: '0002' },
+        { ...ACTION_AF1, parcelName: 'NY0002' }
+      ]
+    }
+  ]
+}

--- a/src/services/dal/index.js
+++ b/src/services/dal/index.js
@@ -1,0 +1,36 @@
+import { GET_BUSINESS } from './queries.js'
+import { config } from '~/src/config/index.js'
+import { dalBusinessToAgreements } from '~/src/features/agreements/transformers/agreements.transformer.js'
+import { proxyFetch } from '~/src/features/common/helpers/proxy.js'
+
+/**
+ * Fetches existing Siti Agri agreements for a business from the DAL
+ * @param {string} sbi - Single Business Identifier
+ * @returns {Promise<AgreementAction[]>} The existing agreements for the sbi
+ */
+export async function getAgreements(sbi, parcelId, sheetId, defraIdToken) {
+  const endpoint = config.get('dal.apiEndpoint')
+
+  const response = await proxyFetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Gateway-Type': 'external',
+      'X-Forwarded-Authorization': defraIdToken
+    },
+    body: JSON.stringify({ query: GET_BUSINESS, variables: { sbi } })
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch existing DAL agreements for sbi=${sbi}: ${response.status} ${response.statusText}`
+    )
+  }
+
+  const body = await response.json()
+  return dalBusinessToAgreements(body.data.business, parcelId, sheetId)
+}
+
+/**
+ * @import { AgreementAction } from '~/src/features/agreements/agreements.d.js'
+ */

--- a/src/services/dal/index.test.js
+++ b/src/services/dal/index.test.js
@@ -1,0 +1,65 @@
+import * as proxy from '~/src/features/common/helpers/proxy.js'
+import { GET_BUSINESS } from './queries.js'
+import {
+  PARCEL_ID,
+  SHEET_ID,
+  SIMPLE_BUSINESS
+} from '~/src/services/dal/fixtures/business.js'
+import { config } from '~/src/config/index.js'
+import { dalBusinessToAgreements } from '~/src/features/agreements/transformers/agreements.transformer.js'
+import { getAgreements } from './index.js'
+
+vi.mock('~/src/features/common/helpers/proxy.js')
+
+const stubEndpoint = 'http://stub-dal/graphql'
+const dalResponse = { data: { business: SIMPLE_BUSINESS } }
+
+describe('getAgreements', () => {
+  const sbi = '123456789'
+
+  afterEach(() => {
+    config.set('dal.apiEndpoint', config.default('dal.apiEndpoint'))
+  })
+
+  beforeEach(() => {
+    config.set('dal.apiEndpoint', stubEndpoint)
+    vi.clearAllMocks()
+  })
+
+  it('should provide agreements from DAL', async () => {
+    proxy.proxyFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(dalResponse)
+    })
+
+    const result = await getAgreements(sbi, PARCEL_ID, SHEET_ID, 'dummy')
+
+    expect(proxy.proxyFetch).toHaveBeenCalledWith(
+      stubEndpoint,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Gateway-Type': 'external',
+          'X-Forwarded-Authorization': 'dummy'
+        }),
+        body: JSON.stringify({ query: GET_BUSINESS, variables: { sbi } })
+      })
+    )
+    expect(result).toEqual(
+      dalBusinessToAgreements(dalResponse.data.business, PARCEL_ID, SHEET_ID)
+    )
+  })
+
+  it('throws when the DAL response is not ok', async () => {
+    proxy.proxyFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    })
+
+    await expect(
+      getAgreements(sbi, PARCEL_ID, SHEET_ID, 'dummy')
+    ).rejects.toThrow()
+  })
+})

--- a/src/services/dal/queries.js
+++ b/src/services/dal/queries.js
@@ -1,0 +1,19 @@
+export const GET_BUSINESS = `
+  query GetBusiness($sbi: ID!) {
+    business(sbi: $sbi) {
+      agreements {
+        status
+        paymentSchedules {
+          optionCode
+          sheetName
+          parcelName
+          actionArea
+          actionMTL
+          actionUnits
+          startDate
+          endDate
+        }
+      }
+    }
+  }
+`

--- a/vitest.unit.config.js
+++ b/vitest.unit.config.js
@@ -15,7 +15,8 @@ export default defineConfig({
       '**/src/rules-engine/**/*.test.js',
       '**/src/features/available-area/**/*.test.js',
       '**/src/payment-calculation/**/*.test.js',
-      '**/src/routes/**/*.test.js'
+      '**/src/routes/**/*.test.js',
+      '**/src/services/**/*.test.js'
     ],
     exclude: ['.server'],
     globals: true,
@@ -32,7 +33,8 @@ export default defineConfig({
         'src/rules-engine/**/*.js',
         'src/features/available-area/**/*.js',
         'src/payment-calculation/**/*.js',
-        'src/routes/**/*.js'
+        'src/routes/**/*.js',
+        'src/services/**/*.js'
       ],
       exclude: [
         'src/**/*.test.js',


### PR DESCRIPTION
    GSPS-447: Fetch agreements from DAL
    
    Add a call to DAL's graphql using their business endpoint and retrieve
    data matching what we ingested into postgres from CSV for early testing.
    
    This call isn't used yet but will be used by the parcel and agreement
    validation endpoints to calculate AACs and validate agreements, in
    addition to postgres agreement data, in upcoming tickets.
    
    Add a Makefile for ease of use