### PR TITLE
GSPS-493: Add optional sbi field to /v2/parcels

### DIFF
--- a/src/features/parcel/schema/2.0.0/parcel.schema.js
+++ b/src/features/parcel/schema/2.0.0/parcel.schema.js
@@ -34,6 +34,7 @@ const parcelSchema = Joi.object({
 })
 
 const parcelsSchema = Joi.object({
+  sbi: Joi.string().optional(),
   parcelIds: Joi.array().items(parcelIdSchema).required(),
   fields: Joi.array()
     .items(

--- a/src/features/parcel/schema/2.0.0/parcel.schema.test.js
+++ b/src/features/parcel/schema/2.0.0/parcel.schema.test.js
@@ -84,6 +84,7 @@ describe('Parcel Schema Validation v2', () => {
 
   describe('parcelsSchema', () => {
     const validParcelsRequest = {
+      sbi: '012345678',
       parcelIds: ['SX0679-9238', 'AB1234-5678'],
       fields: ['size', 'actions'],
       plannedActions: [{ actionCode: 'UPL1', quantity: 0.00001, unit: 'ha' }]
@@ -129,6 +130,12 @@ describe('Parcel Schema Validation v2', () => {
 
     it('should allow empty parcelIds array', () => {
       const valid = { ...validParcelsRequest, parcelIds: [] }
+      const result = parcelsSchema.validate(valid)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should allow missing SBI', () => {
+      const valid = { ...validParcelsRequest, sbi: undefined }
       const result = parcelsSchema.validate(valid)
       expect(result.error).toBeUndefined()
     })


### PR DESCRIPTION
This will be required for retrieving agreements from DAL, so we need to
accept it from Grants UI. We'll ignore it for now but start using it
with upcoming DAL work.
