### PR TITLE
GSPS-461: Use sqm for calculations

### DIFF
--- a/src/features/application/service/action-validation.service.js
+++ b/src/features/application/service/action-validation.service.js
@@ -1,4 +1,3 @@
-import { sqmToHaRounded } from '~/src/features/common/helpers/measurement.js'
 import { getMoorlandInterceptPercentage } from '~/src/features/parcel/queries/getMoorlandInterceptPercentage.js'
 import { getAvailableAreaDataRequirements } from '~/src/features/available-area/availableAreaDataRequirements.js'
 import {
@@ -134,7 +133,7 @@ const buildRuleEngineApplication = async (
   return ruleEngineApplicationTransformer(
     action.quantity,
     action.code,
-    sqmToHaRounded(availableArea.availableAreaSqm),
+    availableArea.availableAreaSqm,
     intersectingAreaPercentage,
     sssiDataLayerData,
     historicFeaturesDataLayerData,

--- a/src/features/application/transformers/application.transformer.js
+++ b/src/features/application/transformers/application.transformer.js
@@ -144,7 +144,7 @@ export const applicationDataTransformer = (
  * Transform the application data
  * @param {number} areaAppliedFor - The area applied for
  * @param {string} code - The code of the action
- * @param {number} area - The area of the parcel
+ * @param {number} availableAreaSqm - The area of the parcel
  * @param {number} intersectingAreaPercentage - The intersecting area percentage
  * @param {object} sssiDataLayerData - The sssi data
  * @param {object} historicFeaturesDataLayerData - The historic features data
@@ -154,7 +154,7 @@ export const applicationDataTransformer = (
 export function ruleEngineApplicationTransformer(
   areaAppliedFor,
   code,
-  area,
+  availableAreaSqm,
   intersectingAreaPercentage,
   sssiDataLayerData,
   historicFeaturesDataLayerData,
@@ -164,7 +164,7 @@ export function ruleEngineApplicationTransformer(
     areaAppliedFor,
     actionCodeAppliedFor: code,
     landParcel: {
-      area,
+      availableAreaSqm,
       existingAgreements,
       intersections: {
         moorland: { intersectingAreaPercentage },

--- a/src/features/application/transformers/application.transformer.test.js
+++ b/src/features/application/transformers/application.transformer.test.js
@@ -455,7 +455,7 @@ describe('ruleEngineApplicationTransformer', () => {
       areaAppliedFor: 100,
       actionCodeAppliedFor: 'UPL1',
       landParcel: {
-        area: 500,
+        availableAreaSqm: 500,
         existingAgreements: [
           { id: 'AG1', type: 'agreement1' },
           { id: 'AG2', type: 'agreement2' }
@@ -497,7 +497,7 @@ describe('ruleEngineApplicationTransformer', () => {
       areaAppliedFor: 0,
       actionCodeAppliedFor: 'UPL1',
       landParcel: {
-        area: 0,
+        availableAreaSqm: 0,
         existingAgreements: [],
         intersections: {
           moorland: { intersectingAreaPercentage: 0 },
@@ -526,7 +526,7 @@ describe('ruleEngineApplicationTransformer', () => {
       areaAppliedFor: -100,
       actionCodeAppliedFor: 'UPL1',
       landParcel: {
-        area: -500,
+        availableAreaSqm: -500,
         existingAgreements: [],
         intersections: {
           moorland: { intersectingAreaPercentage: -25.5 },
@@ -558,7 +558,7 @@ describe('ruleEngineApplicationTransformer', () => {
       areaAppliedFor: null,
       actionCodeAppliedFor: 'UPL1',
       landParcel: {
-        area: undefined,
+        availableAreaSqm: undefined,
         existingAgreements: null,
         intersections: {
           moorland: { intersectingAreaPercentage: 0 },

--- a/src/features/parcel/service/2.0.0/parcel.service.js
+++ b/src/features/parcel/service/2.0.0/parcel.service.js
@@ -187,7 +187,7 @@ export async function getActionsForParcelWithSSSIConsentRequired(
     areaAppliedFor: 0,
     actionCodeAppliedFor: '',
     landParcel: {
-      area: 0,
+      availableAreaSqm: 0,
       existingAgreements: [],
       intersections: {
         sssi: { intersectingAreaPercentage }
@@ -229,7 +229,7 @@ export async function getActionsForParcelWithHEFERConsentRequired(
     areaAppliedFor: 0,
     actionCodeAppliedFor: '',
     landParcel: {
-      area: 0,
+      availableAreaSqm: 0,
       existingAgreements: [],
       intersections: {
         historic_features: { intersectingAreaPercentage }

--- a/src/features/parcel/transformers/parcelActions.transformer.js
+++ b/src/features/parcel/transformers/parcelActions.transformer.js
@@ -46,22 +46,6 @@ function actionTransformer(action, availableArea = null, showResults = false) {
 }
 
 /**
- * Transform parcel and actions to land parcel and actions
- * @param {object} landParcel - The parcel to merge
- * @param {object} actions - The actions to merge
- */
-function parcelTransformer(landParcel, actions) {
-  return {
-    parcel: {
-      parcelId: landParcel?.parcel_id,
-      sheetId: landParcel?.sheet_id,
-      size: sizeTransformer(landParcel.area_sqm),
-      actions
-    }
-  }
-}
-
-/**
  * Transform parcel to land parcel
  * @param {object} landParcel - The parcel to merge
  */
@@ -147,7 +131,6 @@ function heferRequiredActionTransformer(responseParcels, heferRequiredAction) {
 export {
   actionTransformer,
   parcelActionsTransformer,
-  parcelTransformer,
   plannedActionsTransformer,
   sizeTransformer,
   sssiConsentRequiredActionTransformer,

--- a/src/features/parcel/transformers/parcelActions.transformer.test.js
+++ b/src/features/parcel/transformers/parcelActions.transformer.test.js
@@ -1,6 +1,5 @@
 import {
   actionTransformer,
-  parcelTransformer,
   parcelActionsTransformer,
   plannedActionsTransformer,
   sizeTransformer,
@@ -161,63 +160,6 @@ describe('actionTransformer', () => {
       availableArea: {
         unit: 'ha',
         value: 500
-      }
-    })
-  })
-})
-
-describe('parcelTransformer', () => {
-  test('should transform land parcel with actions', () => {
-    const landParcel = {
-      parcel_id: 'P123',
-      sheet_id: 'S456',
-      area_sqm: 2000
-    }
-    const actions = [
-      {
-        code: 'ACTION1',
-        description: 'Test Action 1',
-        availableArea: {
-          unit: 'ha',
-          value: 1000
-        }
-      }
-    ]
-
-    const result = parcelTransformer(landParcel, actions)
-
-    expect(result).toEqual({
-      parcel: {
-        parcelId: 'P123',
-        sheetId: 'S456',
-        size: {
-          unit: 'ha',
-          value: 2000
-        },
-        actions
-      }
-    })
-  })
-
-  test('should handle null parcel_id and sheet_id', () => {
-    const landParcel = {
-      parcel_id: null,
-      sheet_id: null,
-      area_sqm: 2000
-    }
-    const actions = []
-
-    const result = parcelTransformer(landParcel, actions)
-
-    expect(result).toEqual({
-      parcel: {
-        parcelId: null,
-        sheetId: null,
-        size: {
-          unit: 'ha',
-          value: 2000
-        },
-        actions: []
       }
     })
   })

--- a/src/features/rules-engine/rules.d.js
+++ b/src/features/rules-engine/rules.d.js
@@ -22,7 +22,7 @@
 
 /**
  * @typedef {object} LandParcel
- * @property {number} area
+ * @property {number} availableAreaSqm
  * @property {Array} existingAgreements
  * @property {object} intersections
  */

--- a/src/features/rules-engine/rules/1.0.0/applied-for-total-available-area.js
+++ b/src/features/rules-engine/rules/1.0.0/applied-for-total-available-area.js
@@ -1,3 +1,8 @@
+import {
+  haToSqm,
+  sqmToHaRounded
+} from '~/src/features/common/helpers/measurement.js'
+
 /**
  * @import { RuleEngineApplication } from '~/src/features/rules-engine/rules.d.js'
  * @import { ActionRule } from '~/src/features/actions/action.d.js'
@@ -12,25 +17,29 @@ export const appliedForTotalAvailableArea = {
   execute: (application, rule) => {
     const {
       areaAppliedFor,
-      landParcel: { area }
+      landParcel: { availableAreaSqm }
     } = application
+
+    const areaAppliedForHa = Number.parseFloat(areaAppliedFor)
+    const availableAreaHa = sqmToHaRounded(availableAreaSqm)
+    const areaAppliedForSqm = haToSqm(areaAppliedForHa)
 
     const name = rule.name
     const explanations = [
       {
         title: 'Total valid land cover',
         lines: [
-          `The available area was (${Number.parseFloat(area)} ha) the applicant applied for (${Number.parseFloat(areaAppliedFor)} ha)`
+          `The available area was (${availableAreaHa} ha) the applicant applied for (${areaAppliedFor} ha)`
         ]
       }
     ]
 
-    if (Number.parseFloat(areaAppliedFor) !== Number.parseFloat(area)) {
+    if (areaAppliedForSqm !== availableAreaSqm) {
       return {
         name,
         passed: false,
         description: rule.description,
-        reason: `There is not sufficient available area (${Number.parseFloat(area)} ha) for the applied figure (${Number.parseFloat(areaAppliedFor)} ha)`,
+        reason: `There is not sufficient available area (${availableAreaHa} ha) for the applied figure (${areaAppliedForHa} ha)`,
         explanations
       }
     }
@@ -39,7 +48,7 @@ export const appliedForTotalAvailableArea = {
       name,
       passed: true,
       description: rule.description,
-      reason: `There is sufficient available area (${Number.parseFloat(area)} ha) for the applied figure (${Number.parseFloat(areaAppliedFor)} ha)`,
+      reason: `There is sufficient available area (${availableAreaHa} ha) for the applied figure (${areaAppliedForHa} ha)`,
       explanations
     }
   }

--- a/src/features/rules-engine/rules/1.0.0/applied-for-total-available-area.test.js
+++ b/src/features/rules-engine/rules/1.0.0/applied-for-total-available-area.test.js
@@ -1,10 +1,11 @@
 import { appliedForTotalAvailableArea } from './applied-for-total-available-area.js'
+import { haToSqm } from '~/src/features/common/helpers/measurement.js'
 
 describe('appliedForTotalAvailableArea', () => {
   const createApplication = (areaAppliedFor, parcelArea) => ({
     areaAppliedFor,
     landParcel: {
-      area: parcelArea
+      availableAreaSqm: haToSqm(Number.parseFloat(parcelArea))
     }
   })
 

--- a/src/features/rules-engine/rules/1.0.0/applied-for-total-or-partial-available-area.js
+++ b/src/features/rules-engine/rules/1.0.0/applied-for-total-or-partial-available-area.js
@@ -1,5 +1,10 @@
+import {
+  haToSqm,
+  sqmToHaRounded
+} from '~/src/features/common/helpers/measurement.js'
+
 /**
- * @import { RuleEngineApplication, RuleResultItem } from '~/src/features/rules-engine/rules.d.js'
+ * @import { RuleEngineApplication } from '~/src/features/rules-engine/rules.d.js'
  * @import { ActionRule } from '~/src/features/actions/action.d.js'
  */
 
@@ -13,27 +18,30 @@
 export const appliedForTotalOrPartialAvailableArea = {
   execute: (application, rule) => {
     const {
-      areaAppliedFor,
-      landParcel: { area: availableArea }
+      areaAppliedFor: areaAppliedForHa,
+      landParcel: { availableAreaSqm }
     } = application
     const name = rule.name
 
-    const parsedAppliedArea = Number.parseFloat(areaAppliedFor) || 0
-    const parsedAvailableArea = Number.parseFloat(availableArea) || 0
-    const maximumAllowedAppliedArea = parsedAvailableArea
+    const parsedAppliedAreaHa = Number.parseFloat(areaAppliedForHa) || 0
+    const parsedAvailableAreaHa = sqmToHaRounded(availableAreaSqm) || 0
+    const maximumAllowedAppliedAreaHa = parsedAvailableAreaHa
+
+    const parsedAppliedAreaSqm = haToSqm(parsedAppliedAreaHa)
+    const maximumAllowedAppliedAreaSqm = haToSqm(maximumAllowedAppliedAreaHa)
 
     const explanations = [
       {
         title: 'Total or partial available area',
         lines: [
-          `The available area is (${parsedAvailableArea} ha), and the applicant applied for (${parsedAppliedArea} ha).`
+          `The available area is (${parsedAvailableAreaHa} ha), and the applicant applied for (${parsedAppliedAreaHa} ha).`
         ]
       }
     ]
 
     if (
-      parsedAppliedArea <= 0 ||
-      parsedAppliedArea > maximumAllowedAppliedArea
+      parsedAppliedAreaSqm <= 0 ||
+      parsedAppliedAreaSqm > maximumAllowedAppliedAreaSqm
     ) {
       return {
         name,
@@ -48,7 +56,7 @@ export const appliedForTotalOrPartialAvailableArea = {
       name,
       passed: true,
       description: rule.description,
-      reason: `The applied figure (${parsedAppliedArea} ha) is within the allowed range (greater than 0 ha and up to ${maximumAllowedAppliedArea} ha)`,
+      reason: `The applied figure (${parsedAppliedAreaHa} ha) is within the allowed range (greater than 0 ha and up to ${maximumAllowedAppliedAreaHa} ha)`,
       explanations
     }
   }

--- a/src/features/rules-engine/rules/1.0.0/applied-for-total-or-partial-available-area.test.js
+++ b/src/features/rules-engine/rules/1.0.0/applied-for-total-or-partial-available-area.test.js
@@ -1,10 +1,11 @@
 import { appliedForTotalOrPartialAvailableArea } from './applied-for-total-or-partial-available-area.js'
+import { haToSqm } from '~/src/features/common/helpers/measurement.js'
 
 describe('appliedForTotalOrPartialAvailableArea', () => {
   const createApplication = (areaAppliedFor, parcelArea) => ({
     areaAppliedFor,
     landParcel: {
-      area: parcelArea
+      availableAreaSqm: haToSqm(Number.parseFloat(parcelArea))
     }
   })
 


### PR DESCRIPTION
Uses sqm rather than hectares for any calculations:

- action validation
- applied for total available area rule
- applied for total or partial available area rule