### PR TITLE
GSPS-475 Audit case-management re-run and WMP payment/validation flows

### DIFF
--- a/src/features/application/controllers/2.0.0/application-validation.controller.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.js
@@ -202,7 +202,7 @@ const handleValidationError = async (error, request) => {
   })
 
   await auditEvent(
-    AuditEvent.APPLICATION_VALIDATED,
+    AuditEvent.SFI_APPLICATION_VALIDATED,
     {
       ...buildAuditContext(request, { applicationId, sbi, applicantCrn }),
       request: { landActions },
@@ -232,7 +232,7 @@ const sendValidationAuditEvent = async (
   { applicationId, sbi, applicantCrn, landActions, responseData }
 ) => {
   await auditEvent(
-    AuditEvent.APPLICATION_VALIDATED,
+    AuditEvent.SFI_APPLICATION_VALIDATED,
     {
       ...buildAuditContext(request, { applicationId, sbi, applicantCrn }),
       request: { landActions },

--- a/src/features/application/controllers/2.0.0/application-validation.controller.test.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.test.js
@@ -273,7 +273,7 @@ describe('ApplicationValidationController', () => {
       await server.inject(request)
 
       expect(mockAuditEvent).toHaveBeenCalledWith(
-        AuditEvent.APPLICATION_VALIDATED,
+        AuditEvent.SFI_APPLICATION_VALIDATED,
         expect.objectContaining({
           applicationId,
           identifiers: { sbi, crn: 'CRN-456' },
@@ -316,7 +316,7 @@ describe('ApplicationValidationController', () => {
       await server.inject(request)
 
       expect(mockAuditEvent).toHaveBeenCalledWith(
-        AuditEvent.APPLICATION_VALIDATED,
+        AuditEvent.SFI_APPLICATION_VALIDATED,
         expect.objectContaining({
           applicationId: 'APP-123',
           identifiers: { sbi: 123456789, crn: 'CRN-456' },

--- a/src/features/case-management-adapter/controllers/case-management-application-validation.controller.js
+++ b/src/features/case-management-adapter/controllers/case-management-application-validation.controller.js
@@ -15,6 +15,170 @@ import {
   logValidationWarn,
   logBusinessError
 } from '~/src/features/common/helpers/logging/log-helpers.js'
+import {
+  AuditEvent,
+  auditEvent,
+  getCorrelationId
+} from '~/src/features/common/helpers/audit-event.js'
+
+/**
+ * Builds the shared portion of a case management application validation
+ * audit context.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} params
+ * @param {string} params.applicationId
+ * @param {string} params.sbi
+ * @param {string} params.crn
+ * @returns {object}
+ */
+const buildAuditContext = (request, { applicationId, sbi, crn }) => ({
+  correlationId: getCorrelationId(request),
+  applicationId,
+  identifiers: { sbi, crn }
+})
+
+/**
+ * Fetches the application validation run to re-run, returning a 404 Boom
+ * response when it cannot be found.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} postgresDb
+ * @param {string} id
+ * @returns {Promise<object | import('@hapi/boom').Boom>}
+ */
+const fetchApplicationValidationRun = async (request, postgresDb, id) => {
+  const applicationValidationRun = await getApplicationValidationRun(
+    request.logger,
+    postgresDb,
+    id
+  )
+
+  if (!applicationValidationRun) {
+    logResourceNotFound(request.logger, {
+      resourceType: 'Application validation run',
+      context: { validationRunId: id }
+    })
+    return Boom.notFound('Application validation run not found')
+  }
+
+  return applicationValidationRun
+}
+
+/**
+ * Runs the eligibility re-validation for a case management validation run,
+ * persists the result and publishes the success audit event.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} applicationValidationRun
+ * @param {object} params
+ * @param {string} params.requesterUsername
+ * @param {string} params.id
+ * @returns {Promise<object | import('@hapi/boom').Boom>}
+ */
+const runCaseManagementValidation = async (
+  request,
+  applicationValidationRun,
+  { requesterUsername, id }
+) => {
+  const {
+    sbi,
+    crn,
+    application_id: applicationId,
+    data
+  } = applicationValidationRun
+
+  const { validationErrors, applicationData, applicationValidationRunId } =
+    await validateApplication(
+      data.application.parcels,
+      applicationId,
+      crn,
+      sbi,
+      requesterUsername,
+      request
+    )
+
+  if (validationErrors && validationErrors.length > 0) {
+    logValidationWarn(request.logger, {
+      operation: 'Case management application validation',
+      errors: validationErrors.map((err) => err.message),
+      context: {
+        sbi,
+        crn,
+        validationRunId: id,
+        requesterUsername,
+        applicationId
+      }
+    })
+    return Boom.badRequest(
+      validationErrors.map((err) => err.message).join(', ')
+    )
+  }
+
+  await auditEvent(
+    AuditEvent.SFI_APPLICATION_VALIDATED,
+    {
+      ...buildAuditContext(request, { applicationId, sbi, crn }),
+      request: {
+        validationRunId: id,
+        requesterUsername,
+        parcels: data.application.parcels
+      },
+      response: {
+        valid: applicationData.hasPassed,
+        id: applicationValidationRunId
+      }
+    },
+    'success',
+    request
+  )
+
+  return {
+    message: 'Application validated successfully',
+    valid: applicationData.hasPassed,
+    id: applicationValidationRunId,
+    date: applicationData.date
+  }
+}
+
+/**
+ * Handles unexpected errors thrown while re-running a case management
+ * application validation: logs the error and publishes a failure audit
+ * event.
+ * @param {Error} error
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object|undefined} applicationValidationRun
+ * @returns {Promise<import('@hapi/boom').Boom>}
+ */
+const handleCaseManagementValidationError = async (
+  error,
+  request,
+  applicationValidationRun
+) => {
+  // @ts-expect-error - payload
+  const { requesterUsername, id } = request.payload
+  logBusinessError(request.logger, {
+    operation: 'Case Management validation run',
+    error,
+    context: { validationRunId: id, requesterUsername }
+  })
+
+  await auditEvent(
+    AuditEvent.SFI_APPLICATION_VALIDATED,
+    {
+      ...(applicationValidationRun
+        ? buildAuditContext(request, {
+            applicationId: applicationValidationRun.application_id,
+            sbi: applicationValidationRun.sbi,
+            crn: applicationValidationRun.crn
+          })
+        : { correlationId: getCorrelationId(request) }),
+      request: { validationRunId: id, requesterUsername },
+      error: error.message
+    },
+    'failure',
+    request
+  )
+
+  return Boom.internal('Error validating application')
+}
 
 const CaseManagementApplicationValidationController = {
   options: {
@@ -41,83 +205,38 @@ const CaseManagementApplicationValidationController = {
    * @returns {Promise<import('@hapi/hapi').ResponseObject | import('@hapi/boom').Boom>} Validation response
    */
   handler: async (request, h) => {
+    let applicationValidationRun
     try {
       // @ts-expect-error - postgresDb
       const postgresDb = request.server.postgresDb
       // @ts-expect-error - payload
       const { requesterUsername, id } = request.payload
 
-      const applicationValidationRun = await getApplicationValidationRun(
-        request.logger,
+      applicationValidationRun = await fetchApplicationValidationRun(
+        request,
         postgresDb,
         id
       )
-
-      if (!applicationValidationRun) {
-        logResourceNotFound(request.logger, {
-          resourceType: 'Application validation run',
-          context: {
-            validationRunId: id
-          }
-        })
-        return Boom.notFound('Application validation run not found')
+      if (Boom.isBoom(applicationValidationRun)) {
+        return applicationValidationRun
       }
 
-      const {
-        sbi,
-        crn,
-        application_id: applicationId,
-        data
-      } = applicationValidationRun
-
-      const { validationErrors, applicationData, applicationValidationRunId } =
-        await validateApplication(
-          data.application.parcels,
-          applicationId,
-          crn,
-          sbi,
-          requesterUsername,
-          request
-        )
-
-      if (validationErrors && validationErrors.length > 0) {
-        logValidationWarn(request.logger, {
-          operation: 'Case management application validation',
-          errors: validationErrors.map((err) => err.message),
-          context: {
-            sbi,
-            crn,
-            validationRunId: id,
-            requesterUsername,
-            applicationId
-          }
-        })
-        return Boom.badRequest(
-          validationErrors.map((err) => err.message).join(', ')
-        )
+      const validationResult = await runCaseManagementValidation(
+        request,
+        applicationValidationRun,
+        { requesterUsername, id }
+      )
+      if (Boom.isBoom(validationResult)) {
+        return validationResult
       }
 
-      // Return the application validation result
-      return h
-        .response({
-          message: 'Application validated successfully',
-          valid: applicationData.hasPassed,
-          id: applicationValidationRunId,
-          date: applicationData.date
-        })
-        .code(statusCodes.ok)
+      return h.response(validationResult).code(statusCodes.ok)
     } catch (error) {
-      // @ts-expect-error - postgresDb
-      const { requesterUsername, id } = request.payload
-      logBusinessError(request.logger, {
-        operation: 'Case Management validation run',
+      return handleCaseManagementValidationError(
         error,
-        context: {
-          validationRunId: id,
-          requesterUsername
-        }
-      })
-      return Boom.internal('Error validating application')
+        request,
+        applicationValidationRun
+      )
     }
   }
 }

--- a/src/features/case-management-adapter/controllers/case-management-application-validation.controller.test.js
+++ b/src/features/case-management-adapter/controllers/case-management-application-validation.controller.test.js
@@ -2,12 +2,19 @@ import Hapi from '@hapi/hapi'
 import { caseManagementAdapter } from '../index.js'
 import { getApplicationValidationRun } from '~/src/features/application/queries/getApplicationValidationRun.query.js'
 import { validateApplication } from '../../application/service/application-validation.service.js'
+import {
+  AuditEvent,
+  auditEvent
+} from '~/src/features/common/helpers/audit-event.js'
 import { vi } from 'vitest'
 
 vi.mock(
   '~/src/features/application/queries/getApplicationValidationRun.query.js'
 )
 vi.mock('../../application/service/application-validation.service.js')
+vi.mock('~/src/features/common/helpers/audit-event.js')
+
+const mockAuditEvent = auditEvent
 
 describe('Case Management Application Validation Controller', () => {
   const server = Hapi.server()
@@ -139,6 +146,20 @@ describe('Case Management Application Validation Controller', () => {
           server: expect.objectContaining({ postgresDb: expect.any(Object) })
         })
       )
+
+      expect(mockAuditEvent).toHaveBeenCalledWith(
+        AuditEvent.SFI_APPLICATION_VALIDATED,
+        expect.objectContaining({
+          applicationId: mockApplicationValidationRun.application_id,
+          identifiers: {
+            sbi: mockApplicationValidationRun.sbi,
+            crn: mockApplicationValidationRun.crn
+          },
+          response: { valid: true, id: 1 }
+        }),
+        'success',
+        expect.objectContaining({ method: 'post' })
+      )
     })
 
     test('should return 404 when application validation run is not found', async () => {
@@ -167,6 +188,7 @@ describe('Case Management Application Validation Controller', () => {
       )
 
       expect(validateApplication).not.toHaveBeenCalled()
+      expect(mockAuditEvent).not.toHaveBeenCalled()
     })
 
     test('should return 400 when payload is missing requesterUsername', async () => {
@@ -257,6 +279,8 @@ describe('Case Management Application Validation Controller', () => {
         },
         'Validation failed: Case management application validation [sbi=123456789 | crn=1234567890 | validationRunId=1 | requesterUsername=test.user@example.com | applicationId=APP-123456]'
       )
+
+      expect(mockAuditEvent).not.toHaveBeenCalled()
     })
 
     test('should return 500 when validateApplication fails', async () => {
@@ -290,6 +314,20 @@ describe('Case Management Application Validation Controller', () => {
           })
         }),
         'Business operation failed: Case Management validation run [validationRunId=1 | requesterUsername=test.user@example.com]'
+      )
+
+      expect(mockAuditEvent).toHaveBeenCalledWith(
+        AuditEvent.SFI_APPLICATION_VALIDATED,
+        expect.objectContaining({
+          applicationId: mockApplicationValidationRun.application_id,
+          identifiers: {
+            sbi: mockApplicationValidationRun.sbi,
+            crn: mockApplicationValidationRun.crn
+          },
+          error: 'Validation service failed'
+        }),
+        'failure',
+        expect.objectContaining({ method: 'post' })
       )
     })
   })

--- a/src/features/common/helpers/audit-event.js
+++ b/src/features/common/helpers/audit-event.js
@@ -40,15 +40,19 @@ export const getCorrelationId = (request) =>
  * @enum {string}
  */
 export const AuditEvent = Object.freeze({
-  PAYMENT_CALCULATED: 'PAYMENT_CALCULATED',
-  APPLICATION_VALIDATED: 'APPLICATION_VALIDATED'
+  SFI_PAYMENT_CALCULATED: 'SFI_PAYMENT_CALCULATED',
+  SFI_APPLICATION_VALIDATED: 'SFI_APPLICATION_VALIDATED',
+  WMP_PAYMENT_CALCULATED: 'WMP_PAYMENT_CALCULATED',
+  WMP_VALIDATED: 'WMP_VALIDATED'
 })
 
 // Human-readable description for each audit event, used in security.details.message
 const eventMessages = {
-  [AuditEvent.PAYMENT_CALCULATED]: 'Payment calculation completed',
-  [AuditEvent.APPLICATION_VALIDATED]:
-    'Application eligibility validation completed'
+  [AuditEvent.SFI_PAYMENT_CALCULATED]: 'Payment calculation completed',
+  [AuditEvent.SFI_APPLICATION_VALIDATED]:
+    'Application eligibility validation completed',
+  [AuditEvent.WMP_PAYMENT_CALCULATED]: 'WMP payment calculation completed',
+  [AuditEvent.WMP_VALIDATED]: 'WMP validation completed'
 }
 
 // Transaction code for each audit event, used in security.details.transactioncode
@@ -60,22 +64,34 @@ const eventPmcCodes = {}
 
 // Audit event type for each audit event, used in audit.eventtype
 const eventTypes = {
-  [AuditEvent.PAYMENT_CALCULATED]: 'GrantsPaymentCalculated',
-  [AuditEvent.APPLICATION_VALIDATED]: 'GrantsApplicationValidated'
+  [AuditEvent.SFI_PAYMENT_CALCULATED]: 'GrantsPaymentCalculated',
+  [AuditEvent.SFI_APPLICATION_VALIDATED]: 'GrantsApplicationValidated',
+  [AuditEvent.WMP_PAYMENT_CALCULATED]: 'GrantsWmpPaymentCalculated',
+  [AuditEvent.WMP_VALIDATED]: 'GrantsWmpValidated'
 }
 
 // Entities for each audit event, used in audit.entities
 // action must be one of: created, read, updated, deleted, submitted, accepted, rejected, withdrawn
 const eventEntities = {
-  [AuditEvent.PAYMENT_CALCULATED]: (context) => [
+  [AuditEvent.SFI_PAYMENT_CALCULATED]: (context) => [
     { entity: 'payment', action: 'read', entityid: context.applicationId }
   ],
-  [AuditEvent.APPLICATION_VALIDATED]: (context) => [
+  [AuditEvent.SFI_APPLICATION_VALIDATED]: (context) => [
     {
       entity: 'application',
       action: 'created',
       entityid: context.applicationId
     }
+  ],
+  [AuditEvent.WMP_PAYMENT_CALCULATED]: (context) => [
+    {
+      entity: 'payment',
+      action: 'read',
+      entityid: context.parcelIds?.join(',')
+    }
+  ],
+  [AuditEvent.WMP_VALIDATED]: (context) => [
+    { entity: 'wmp', action: 'read', entityid: context.parcelIds?.join(',') }
   ]
 }
 

--- a/src/features/common/helpers/audit-event.test.js
+++ b/src/features/common/helpers/audit-event.test.js
@@ -52,8 +52,12 @@ describe('AuditEvent', () => {
   })
 
   test('contains expected event keys', () => {
-    expect(AuditEvent.PAYMENT_CALCULATED).toBe('PAYMENT_CALCULATED')
-    expect(AuditEvent.APPLICATION_VALIDATED).toBe('APPLICATION_VALIDATED')
+    expect(AuditEvent.SFI_PAYMENT_CALCULATED).toBe('SFI_PAYMENT_CALCULATED')
+    expect(AuditEvent.SFI_APPLICATION_VALIDATED).toBe(
+      'SFI_APPLICATION_VALIDATED'
+    )
+    expect(AuditEvent.WMP_PAYMENT_CALCULATED).toBe('WMP_PAYMENT_CALCULATED')
+    expect(AuditEvent.WMP_VALIDATED).toBe('WMP_VALIDATED')
   })
 
   test('cannot be mutated', () => {
@@ -211,6 +215,28 @@ describe('auditEvent', () => {
     expect(getPublishedPayload().ip).toBe('192.168.1.100')
   })
 
+  test('ip is empty when no non-internal IPv4 interface is found', async () => {
+    mockNetworkInterfaces.mockReturnValue({
+      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      eth0: [{ address: 'fe80::1', family: 'IPv6', internal: false }]
+    })
+
+    await auditEvent(UNMAPPED_EVENT, {})
+
+    expect(getPublishedPayload().ip).toBe('')
+  })
+
+  test('skips interface entries that are undefined', async () => {
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: undefined,
+      eth1: [{ address: '10.0.0.9', family: 'IPv4', internal: false }]
+    })
+
+    await auditEvent(UNMAPPED_EVENT, {})
+
+    expect(getPublishedPayload().ip).toBe('10.0.0.9')
+  })
+
   test('passes failure status through to the published payload', async () => {
     await auditEvent(UNMAPPED_EVENT, {}, 'failure')
 
@@ -247,7 +273,7 @@ describe('auditEvent', () => {
   })
 })
 
-describe('auditEvent - PAYMENT_CALCULATED', () => {
+describe('auditEvent - SFI_PAYMENT_CALCULATED', () => {
   let auditEvent
   let AuditEvent
   let mockSend
@@ -283,7 +309,9 @@ describe('auditEvent - PAYMENT_CALCULATED', () => {
   }
 
   test('does not include a security block', async () => {
-    await auditEvent(AuditEvent.PAYMENT_CALCULATED, { applicationId: 'app-1' })
+    await auditEvent(AuditEvent.SFI_PAYMENT_CALCULATED, {
+      applicationId: 'app-1'
+    })
 
     expect(getPublishedPayload().security).toBeUndefined()
   })
@@ -297,7 +325,7 @@ describe('auditEvent - PAYMENT_CALCULATED', () => {
       response: { annualTotalPence: 100000, agreementTotalPence: 300000 }
     }
 
-    await auditEvent(AuditEvent.PAYMENT_CALCULATED, context)
+    await auditEvent(AuditEvent.SFI_PAYMENT_CALCULATED, context)
 
     const payload = getPublishedPayload()
     expect(payload.audit).toMatchObject({
@@ -316,7 +344,7 @@ describe('auditEvent - PAYMENT_CALCULATED', () => {
       sessionId: 'session-abc'
     }
 
-    await auditEvent(AuditEvent.PAYMENT_CALCULATED, context)
+    await auditEvent(AuditEvent.SFI_PAYMENT_CALCULATED, context)
 
     expect(getPublishedPayload()).toMatchObject({
       user: 'test.user@defra.gov.uk',
@@ -325,7 +353,9 @@ describe('auditEvent - PAYMENT_CALCULATED', () => {
   })
 
   test('user and sessionid are omitted when not provided', async () => {
-    await auditEvent(AuditEvent.PAYMENT_CALCULATED, { applicationId: 'app-1' })
+    await auditEvent(AuditEvent.SFI_PAYMENT_CALCULATED, {
+      applicationId: 'app-1'
+    })
 
     const payload = getPublishedPayload()
     expect(payload.user).toBeUndefined()
@@ -333,7 +363,7 @@ describe('auditEvent - PAYMENT_CALCULATED', () => {
   })
 })
 
-describe('auditEvent - APPLICATION_VALIDATED', () => {
+describe('auditEvent - SFI_APPLICATION_VALIDATED', () => {
   let auditEvent
   let AuditEvent
   let mockSend
@@ -369,7 +399,7 @@ describe('auditEvent - APPLICATION_VALIDATED', () => {
   }
 
   test('does not include a security block', async () => {
-    await auditEvent(AuditEvent.APPLICATION_VALIDATED, {
+    await auditEvent(AuditEvent.SFI_APPLICATION_VALIDATED, {
       applicationId: 'app-1'
     })
 
@@ -400,7 +430,7 @@ describe('auditEvent - APPLICATION_VALIDATED', () => {
       }
     }
 
-    await auditEvent(AuditEvent.APPLICATION_VALIDATED, context)
+    await auditEvent(AuditEvent.SFI_APPLICATION_VALIDATED, context)
 
     const payload = getPublishedPayload()
     expect(payload.audit).toMatchObject({
@@ -411,6 +441,145 @@ describe('auditEvent - APPLICATION_VALIDATED', () => {
       status: 'success',
       details: context,
       accounts: { sbi: 123456789, crn: 'CRN-001' }
+    })
+  })
+})
+
+describe('auditEvent - WMP_PAYMENT_CALCULATED', () => {
+  let auditEvent
+  let AuditEvent
+  let mockSend
+
+  beforeEach(async () => {
+    vi.resetModules()
+    mockSend = vi.fn().mockResolvedValue({})
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
+    })
+    vi.doMock('@aws-sdk/client-sns', () => ({
+      SNSClient: vi.fn().mockImplementation(function () {
+        this.send = mockSend
+      }),
+      PublishCommand: vi.fn().mockImplementation(function (input) {
+        this.input = input
+      })
+    }))
+    vi.doMock('~/src/features/common/helpers/logging/logger.js', () => ({
+      createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn() }))
+    }))
+    ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  const getPublishedPayload = () => {
+    const [publishCommandInstance] = mockSend.mock.calls[0]
+    return JSON.parse(publishCommandInstance.input.Message)
+  }
+
+  test('does not include a security block', async () => {
+    await auditEvent(AuditEvent.WMP_PAYMENT_CALCULATED, {
+      parcelIds: ['SX067-99238']
+    })
+
+    expect(getPublishedPayload().security).toBeUndefined()
+  })
+
+  test('publishes correct audit fields, including the WMP payment calculation details', async () => {
+    const context = {
+      correlationId: 'corr-xyz',
+      parcelIds: ['SX067-99238', 'SX067-99239'],
+      request: { oldWoodlandAreaHa: 5, newWoodlandAreaHa: 3 },
+      response: { agreementTotalPence: 150000 }
+    }
+
+    await auditEvent(AuditEvent.WMP_PAYMENT_CALCULATED, context)
+
+    const payload = getPublishedPayload()
+    expect(payload.audit).toMatchObject({
+      eventtype: 'GrantsWmpPaymentCalculated',
+      entities: [
+        {
+          entity: 'payment',
+          action: 'read',
+          entityid: 'SX067-99238,SX067-99239'
+        }
+      ],
+      status: 'success',
+      details: context
+    })
+  })
+
+  test('entity id is undefined when parcelIds is absent', async () => {
+    await auditEvent(AuditEvent.WMP_PAYMENT_CALCULATED, {})
+
+    expect(getPublishedPayload().audit.entities).toEqual([
+      { entity: 'payment', action: 'read', entityid: undefined }
+    ])
+  })
+})
+
+describe('auditEvent - WMP_VALIDATED', () => {
+  let auditEvent
+  let AuditEvent
+  let mockSend
+
+  beforeEach(async () => {
+    vi.resetModules()
+    mockSend = vi.fn().mockResolvedValue({})
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
+    })
+    vi.doMock('@aws-sdk/client-sns', () => ({
+      SNSClient: vi.fn().mockImplementation(function () {
+        this.send = mockSend
+      }),
+      PublishCommand: vi.fn().mockImplementation(function (input) {
+        this.input = input
+      })
+    }))
+    vi.doMock('~/src/features/common/helpers/logging/logger.js', () => ({
+      createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn() }))
+    }))
+    ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  const getPublishedPayload = () => {
+    const [publishCommandInstance] = mockSend.mock.calls[0]
+    return JSON.parse(publishCommandInstance.input.Message)
+  }
+
+  test('does not include a security block', async () => {
+    await auditEvent(AuditEvent.WMP_VALIDATED, {
+      parcelIds: ['SX067-99238']
+    })
+
+    expect(getPublishedPayload().security).toBeUndefined()
+  })
+
+  test('publishes correct audit fields, including the WMP validation result', async () => {
+    const context = {
+      correlationId: 'corr-xyz',
+      parcelIds: ['SX067-99238'],
+      response: { result: { hasPassed: true, code: 'PA3' } }
+    }
+
+    await auditEvent(AuditEvent.WMP_VALIDATED, context)
+
+    const payload = getPublishedPayload()
+    expect(payload.audit).toMatchObject({
+      eventtype: 'GrantsWmpValidated',
+      entities: [{ entity: 'wmp', action: 'read', entityid: 'SX067-99238' }],
+      status: 'success',
+      details: context
     })
   })
 })

--- a/src/features/payment/controllers/2.0.0/payment-calculate.controller.js
+++ b/src/features/payment/controllers/2.0.0/payment-calculate.controller.js
@@ -125,7 +125,7 @@ const handleCalculationError = async (request, error) => {
   })
 
   await auditEvent(
-    AuditEvent.PAYMENT_CALCULATED,
+    AuditEvent.SFI_PAYMENT_CALCULATED,
     {
       ...buildAuditContext(request, { applicationId, sbi }),
       request: { parcel, startDate },
@@ -203,7 +203,7 @@ const PaymentsCalculateControllerV2 = {
       })
 
       await auditEvent(
-        AuditEvent.PAYMENT_CALCULATED,
+        AuditEvent.SFI_PAYMENT_CALCULATED,
         {
           ...buildAuditContext(request, { applicationId, sbi }),
           request: { parcel: landActions, startDate },

--- a/src/features/payment/controllers/2.0.0/payment-calculate.controller.test.js
+++ b/src/features/payment/controllers/2.0.0/payment-calculate.controller.test.js
@@ -167,7 +167,7 @@ describe('Payment calculate controller V2', () => {
       await server.inject(request)
 
       expect(mockAuditEvent).toHaveBeenCalledWith(
-        AuditEvent.PAYMENT_CALCULATED,
+        AuditEvent.SFI_PAYMENT_CALCULATED,
         expect.objectContaining({
           applicationId: 'application-1',
           identifiers: { sbi: mockLandActions.sbi },
@@ -392,7 +392,7 @@ describe('Payment calculate controller V2', () => {
       await server.inject(request)
 
       expect(mockAuditEvent).toHaveBeenCalledWith(
-        AuditEvent.PAYMENT_CALCULATED,
+        AuditEvent.SFI_PAYMENT_CALCULATED,
         expect.objectContaining({
           applicationId: 'application-1',
           identifiers: { sbi: mockLandActions.sbi },

--- a/src/features/woodland-management/controller/payment-calculate-wmp.controller.js
+++ b/src/features/woodland-management/controller/payment-calculate-wmp.controller.js
@@ -18,6 +18,116 @@ import { executePaymentMethod } from '../../payments-engine/paymentsEngine.js'
 import { validatePaymentCalculationRequest } from '../validation/payment-calculation.validation.js'
 import { getActionsByLatestVersion } from '../../actions/queries/2.0.0/getActionsByLatestVersion.query.js'
 import { haToSqm } from '../../common/helpers/measurement.js'
+import {
+  AuditEvent,
+  auditEvent,
+  getCorrelationId
+} from '../../common/helpers/audit-event.js'
+
+/**
+ * Builds the shared portion of a WMP payment calculation audit context.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} params
+ * @param {string[]} params.parcelIds
+ * @returns {object}
+ */
+const buildAuditContext = (request, { parcelIds }) => ({
+  correlationId: getCorrelationId(request),
+  parcelIds
+})
+
+/**
+ * Runs the WMP payment calculation pipeline for a validated request.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} postgresDb
+ * @param {object} params
+ * @param {string[]} params.parcelIds
+ * @param {number} params.oldWoodlandAreaHa
+ * @param {number} params.newWoodlandAreaHa
+ * @param {Date} [params.startDate]
+ * @returns {Promise<object | import('@hapi/boom').Boom>} Transformed payment response, or a Boom error response
+ */
+const runWmpPaymentCalculation = async (
+  request,
+  postgresDb,
+  { parcelIds, oldWoodlandAreaHa, newWoodlandAreaHa, startDate }
+) => {
+  const validationResponse = await validatePaymentCalculationRequest(
+    parcelIds,
+    request
+  )
+
+  if (validationResponse.errors && validationResponse.errors.length > 0) {
+    logValidationWarn(request.logger, {
+      operation: 'Payment Calculate WMP validation',
+      errors: validationResponse.errors,
+      context: { parcelIds: parcelIds.join(',') }
+    })
+    return Boom.badRequest(validationResponse.errors.join(', '))
+  }
+
+  const actions = await getActionsByLatestVersion(request.logger, postgresDb)
+  const action = actions.find((a) => a.code === 'PA3')
+
+  if (!action) {
+    return Boom.badRequest('Action not found')
+  }
+
+  const paymentResult = executePaymentMethod(
+    { ...action?.paymentMethod },
+    {
+      data: {
+        oldWoodlandAreaSqm: haToSqm(oldWoodlandAreaHa),
+        newWoodlandAreaSqm: haToSqm(newWoodlandAreaHa)
+      }
+    }
+  )
+
+  return wmpPaymentCalculateTransformer(
+    parcelIds,
+    paymentResult,
+    action,
+    startDate
+  )
+}
+
+/**
+ * Handles unexpected errors thrown during WMP payment calculation: logs the
+ * error, publishes a failure audit event, and returns the client-facing
+ * error response.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {Error} error
+ * @returns {Promise<import('@hapi/boom').Boom>}
+ */
+const handleWmpPaymentCalculationError = async (request, error) => {
+  /** @type {paymentCalculateWMPSchemaV2} */
+  // @ts-expect-error - payload
+  const { parcelIds, oldWoodlandAreaHa, newWoodlandAreaHa, startDate } =
+    request.payload
+  logBusinessError(request.logger, {
+    operation: 'Payment calculation: calculate wmp payment',
+    error,
+    context: {
+      parcelIds: parcelIds.join(','),
+      oldWoodlandAreaHa,
+      newWoodlandAreaHa,
+      startDate
+    }
+  })
+
+  await auditEvent(
+    AuditEvent.WMP_PAYMENT_CALCULATED,
+    {
+      ...buildAuditContext(request, { parcelIds }),
+      request: { oldWoodlandAreaHa, newWoodlandAreaHa, startDate },
+      error: error.message
+    },
+    'failure',
+    request
+  )
+
+  return Boom.internal('Error calculating wmp payment')
+}
 
 export const PaymentsCalculateWMPControllerV2 = {
   options: {
@@ -63,69 +173,34 @@ export const PaymentsCalculateWMPControllerV2 = {
         }
       })
 
-      const validationResponse = await validatePaymentCalculationRequest(
-        parcelIds,
-        request
+      const transformedPayment = await runWmpPaymentCalculation(
+        request,
+        postgresDb,
+        { parcelIds, oldWoodlandAreaHa, newWoodlandAreaHa, startDate }
       )
-
-      if (validationResponse.errors && validationResponse.errors.length > 0) {
-        logValidationWarn(request.logger, {
-          operation: 'Payment Calculate WMP validation',
-          errors: validationResponse.errors,
-          context: {
-            parcelIds: parcelIds.join(',')
-          }
-        })
-        return Boom.badRequest(validationResponse.errors.join(', '))
+      if (Boom.isBoom(transformedPayment)) {
+        return transformedPayment
       }
 
-      const actions = await getActionsByLatestVersion(
-        request.logger,
-        postgresDb
-      )
-      const action = actions.find((a) => a.code === 'PA3')
-
-      if (!action) {
-        return Boom.badRequest('Action not found')
-      }
-
-      const paymentResult = executePaymentMethod(
-        { ...action?.paymentMethod },
+      await auditEvent(
+        AuditEvent.WMP_PAYMENT_CALCULATED,
         {
-          data: {
-            oldWoodlandAreaSqm: haToSqm(oldWoodlandAreaHa),
-            newWoodlandAreaSqm: haToSqm(newWoodlandAreaHa)
-          }
-        }
+          ...buildAuditContext(request, { parcelIds }),
+          request: { oldWoodlandAreaHa, newWoodlandAreaHa, startDate },
+          response: transformedPayment
+        },
+        'success',
+        request
       )
 
       return h
         .response({
           message: 'success',
-          payment: wmpPaymentCalculateTransformer(
-            parcelIds,
-            paymentResult,
-            action,
-            startDate
-          )
+          payment: transformedPayment
         })
         .code(statusCodes.ok)
     } catch (error) {
-      /** @type {paymentCalculateWMPSchemaV2} */
-      // @ts-expect-error - payload
-      const { parcelIds, oldWoodlandAreaHa, newWoodlandAreaHa, startDate } =
-        request.payload
-      logBusinessError(request.logger, {
-        operation: 'Payment calculation: calculate wmp payment',
-        error,
-        context: {
-          parcelIds: parcelIds.join(','),
-          oldWoodlandAreaHa,
-          newWoodlandAreaHa,
-          startDate
-        }
-      })
-      return Boom.internal('Error calculating wmp payment')
+      return handleWmpPaymentCalculationError(request, error)
     }
   }
 }

--- a/src/features/woodland-management/controller/payment-calculate-wmp.controller.test.js
+++ b/src/features/woodland-management/controller/payment-calculate-wmp.controller.test.js
@@ -5,6 +5,10 @@ import { executeRulesForPaymentCalculationWMP } from '../service/wmp-payment-cal
 import { executePaymentMethod } from '../../payments-engine/paymentsEngine.js'
 import { wmpPaymentCalculateTransformer } from '../transformer/wmp-payment-calculate.transformer.js'
 import createTestServer from '~/src/tests/test-server.js'
+import {
+  AuditEvent,
+  auditEvent
+} from '~/src/features/common/helpers/audit-event.js'
 
 vi.mock('~/src/features/parcel/queries/getLandData.query.js')
 vi.mock(
@@ -22,6 +26,7 @@ vi.mock(
 )
 vi.mock('../../payments-engine/paymentsEngine.js')
 vi.mock('../transformer/wmp-payment-calculate.transformer.js')
+vi.mock('~/src/features/common/helpers/audit-event.js')
 
 const mockGetLandData = getLandData
 const mockGetActionsByLatestVersion = getActionsByLatestVersion
@@ -29,6 +34,7 @@ const mockExecuteRulesForPaymentCalculationWMP =
   executeRulesForPaymentCalculationWMP
 const mockExecutePaymentMethod = executePaymentMethod
 const mockWmpPaymentCalculateTransformer = wmpPaymentCalculateTransformer
+const mockAuditEvent = auditEvent
 
 const createMockParcel = () => ({
   id: 1,
@@ -190,6 +196,20 @@ describe('Payment calculate WMP controller', () => {
         expect.objectContaining({ code: 'PA3' }),
         expect.any(Date)
       )
+      expect(mockAuditEvent).toHaveBeenCalledWith(
+        AuditEvent.WMP_PAYMENT_CALCULATED,
+        expect.objectContaining({
+          parcelIds: ['SX067-99238'],
+          request: {
+            oldWoodlandAreaHa: 5,
+            newWoodlandAreaHa: 3,
+            startDate: new Date('2024-01-01')
+          },
+          response: createMockPaymentResponse()
+        }),
+        'success',
+        expect.objectContaining({ method: 'post' })
+      )
     })
 
     test('should return 200 when startDate is not provided, defaulting to next month', async () => {
@@ -224,6 +244,7 @@ describe('Payment calculate WMP controller', () => {
 
       expect(statusCode).toBe(400)
       expect(message).toBe('Land parcels not found: SX067-99238')
+      expect(mockAuditEvent).not.toHaveBeenCalled()
     })
 
     test('should return 400 when no PA3 action exists', async () => {
@@ -436,6 +457,15 @@ describe('Payment calculate WMP controller', () => {
       })
 
       expect(statusCode).toBe(500)
+      expect(mockAuditEvent).toHaveBeenCalledWith(
+        AuditEvent.WMP_PAYMENT_CALCULATED,
+        expect.objectContaining({
+          parcelIds: ['SX067-99238'],
+          error: 'Unexpected transformer error'
+        }),
+        'failure',
+        expect.objectContaining({ method: 'post' })
+      )
     })
   })
 })

--- a/src/features/woodland-management/controller/validate-wmp.controller.js
+++ b/src/features/woodland-management/controller/validate-wmp.controller.js
@@ -16,6 +16,23 @@ import { statusCodes } from '~/src/features/common/constants/status-codes.js'
 import { wmpResultTransformer } from '../transformer/wmp.transformer.js'
 import { getAndValidateParcels } from '../../parcel/validation/2.0.0/parcel.validation.js'
 import { splitParcelId } from '../../parcel/service/2.0.0/parcel.service.js'
+import {
+  AuditEvent,
+  auditEvent,
+  getCorrelationId
+} from '../../common/helpers/audit-event.js'
+
+/**
+ * Builds the shared portion of a WMP validation audit context.
+ * @param {import('@hapi/hapi').Request} request
+ * @param {object} params
+ * @param {string[]} params.parcelIds
+ * @returns {object}
+ */
+const buildAuditContext = (request, { parcelIds }) => ({
+  correlationId: getCorrelationId(request),
+  parcelIds
+})
 
 export const ValidateWMPController = {
   options: {
@@ -70,10 +87,25 @@ export const ValidateWMPController = {
         request
       )
 
+      const transformedResult = wmpResultTransformer(
+        result.action,
+        result.ruleResult
+      )
+
+      await auditEvent(
+        AuditEvent.WMP_VALIDATED,
+        {
+          ...buildAuditContext(request, { parcelIds }),
+          response: { result: transformedResult }
+        },
+        'success',
+        request
+      )
+
       return h
         .response({
           message: 'success',
-          result: wmpResultTransformer(result.action, result.ruleResult)
+          result: transformedResult
         })
         .code(statusCodes.ok)
     } catch (error) {
@@ -91,6 +123,17 @@ export const ValidateWMPController = {
           newWoodlandAreaHa
         }
       })
+
+      await auditEvent(
+        AuditEvent.WMP_VALIDATED,
+        {
+          ...buildAuditContext(request, { parcelIds }),
+          error: error.message
+        },
+        'failure',
+        request
+      )
+
       return Boom.internal('Error validating WMP')
     }
   }

--- a/src/features/woodland-management/controller/validate-wmp.controller.test.js
+++ b/src/features/woodland-management/controller/validate-wmp.controller.test.js
@@ -2,12 +2,18 @@ import { woodlandManagement } from '~/src/features/woodland-management/index.js'
 import { validateWoodlandManagementPlan } from '../service/wmp-service.js'
 import { getAndValidateParcels } from '../../parcel/validation/2.0.0/parcel.validation.js'
 import createTestServer from '~/src/tests/test-server.js'
+import {
+  AuditEvent,
+  auditEvent
+} from '~/src/features/common/helpers/audit-event.js'
 
 vi.mock('../service/wmp-service.js')
 vi.mock('../../parcel/validation/2.0.0/parcel.validation.js')
+vi.mock('~/src/features/common/helpers/audit-event.js')
 
 const mockValidateWoodlandManagementPlan = validateWoodlandManagementPlan
 const mockGetAndValidateParcels = getAndValidateParcels
+const mockAuditEvent = auditEvent
 
 const mockRuleResult = [
   {
@@ -98,6 +104,15 @@ describe('Validate WMP controller', () => {
     expect(statusCode).toBe(200)
     expect(message).toBe('success')
     expect(result).toEqual(mockTransformedResult)
+    expect(mockAuditEvent).toHaveBeenCalledWith(
+      AuditEvent.WMP_VALIDATED,
+      expect.objectContaining({
+        parcelIds: ['SX067-99238'],
+        response: { result: mockTransformedResult }
+      }),
+      'success',
+      expect.objectContaining({ method: 'post' })
+    )
   })
 
   test('should handle error', async () => {
@@ -110,6 +125,7 @@ describe('Validate WMP controller', () => {
         newWoodlandAreaHa: 1
       }
     }
+    mockGetAndValidateParcels.mockResolvedValue(mockParcelValidationResult)
     mockValidateWoodlandManagementPlan.mockRejectedValue(
       new Error('Something went wrong')
     )
@@ -119,6 +135,15 @@ describe('Validate WMP controller', () => {
 
     expect(result.statusCode).toBe(500)
     expect(result.result.message).toBe('An internal server error occurred')
+    expect(mockAuditEvent).toHaveBeenCalledWith(
+      AuditEvent.WMP_VALIDATED,
+      expect.objectContaining({
+        parcelIds: ['SX067-99238'],
+        error: 'Something went wrong'
+      }),
+      'failure',
+      expect.objectContaining({ method: 'post' })
+    )
   })
 
   test('should return not found when a parcel is not found', async () => {
@@ -141,6 +166,7 @@ describe('Validate WMP controller', () => {
 
     expect(result.statusCode).toBe(404)
     expect(result.result.message).toBe('Land parcels not found: SX067-99238')
+    expect(mockAuditEvent).not.toHaveBeenCalled()
   })
 
   test('should return bad request when no oldWoodlandAreaHa', async () => {


### PR DESCRIPTION
Extends the eligibility-decision and payment-calculation audit trail from GSPS-301/GSPS-302 to three endpoints that perform the same class of operation but were left unaudited: 
* the case-management-adapter's application-validation re-run
* WMP payment-calculate
* WMP validate controllers