### PR TITLE
GSPS-448: Use DAL agreements data in AACs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,5 @@ AUTH_HEADER_TOKEN=xxx
 ENABLE_TEST_ENDPOINTS=true
 
 # DAL/Existing agreements
-USE_DAL_AGREEMENTS=true
+FEATURE_USE_DAL=true
 DAL_API_ENDPOINT=http://localhost:3001/graphql

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,9 @@ lint-fix:
 
 test:
 	npm run test:quick
+
+test/all:
+	npm run test && npm run test:db && npm run test:e2e
+
+test/contracts:
+	npm run test:contracts

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ npm run test:ingest
 npm run test:e2e
 ```
 
+#### Run an individual unit test
+
 To run an individual test, you can use:
 
 ```bash
@@ -310,6 +312,28 @@ npx vitest run --config=vitest.unit.config.js [test file]
 ```
 
 You can also filter tests by tags or description; see vitest docs for more details.
+
+#### Run an individual db test
+
+To debug individual db tests without destroying the environment each time, run:
+
+```bash
+npm run test:db:up
+```
+
+which will bring up the db, run tests, and leave the db running. Then you can run individual tests like:
+
+```bash
+npx vitest run --config=vitest.db.config.js
+```
+
+Note the different vitest config file for db tests.
+
+When you're done, destroy the environment with:
+
+```bash
+docker compose -p land-grants-test down --volumes --remove-orphans
+```
 
 ## Database Migrations
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -335,6 +335,14 @@ const config = convict({
       default: '',
       env: 'DAL_API_ENDPOINT'
     }
+  },
+  featureFlags: {
+    useDal: {
+      doc: 'Use DAL to get additional agreements',
+      format: Boolean,
+      default: !isProduction,
+      env: 'FEATURE_USE_DAL'
+    }
   }
 })
 

--- a/src/features/agreements/repo.js
+++ b/src/features/agreements/repo.js
@@ -1,0 +1,36 @@
+import { getAgreementsForParcel as getFromDb } from '~/src/features/agreements/queries/getAgreementsForParcel.query.js'
+import { getAgreements as getFromDal } from '~/src/services/dal/index.js'
+
+/**
+ * Retrieve agreements for a parcel, from multiple sources
+ *
+ * N.B. currently agreements are only fetched in order to calculate available
+ * area, so we filter the results to those which are area-based (sqm).
+ * @param {string} sbi - The SBI for the business owning the parcel
+ * @param {string} sheetId - The sheetId
+ * @param {string} parcelId - The parcelId
+ * @param {string|null} defraIdToken - The user's defra ID token (JWT)
+ * @param {any} db - Database connection
+ * @param {Logger} logger - Logger object
+ * @returns {Promise<AgreementAction[]>} The agreements
+ */
+export async function getAgreements(
+  sbi,
+  sheetId,
+  parcelId,
+  defraIdToken,
+  db,
+  logger
+) {
+  const results = await Promise.all([
+    getFromDb(sheetId, parcelId, db, logger),
+    getFromDal(sbi, parcelId, sheetId, defraIdToken, logger)
+  ])
+
+  return results.flat().filter((a) => a.unit === 'sqm')
+}
+
+/**
+ * @import {AgreementAction} from '~/src/features/agreements/agreements.d.js'
+ * @import {Logger} from '~/src/features/common/logger.d.js'
+ */

--- a/src/features/agreements/repo.test.js
+++ b/src/features/agreements/repo.test.js
@@ -1,0 +1,151 @@
+import * as dal from '~/src/services/dal/index.js'
+import * as db from '~/src/features/agreements/queries/getAgreementsForParcel.query.js'
+import { getAgreements } from '~/src/features/agreements/repo.js'
+
+vi.mock('~/src/features/agreements/queries/getAgreementsForParcel.query.js')
+vi.mock('~/src/services/dal/index.js')
+
+const mockLogger = { info: vi.fn() }
+
+describe('getAgreements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should fetch agreements from both the DB and the DAL', async () => {
+    const sbi = '012345678'
+    const sheetId = 'dummy-sheet'
+    const parcelId = 'dummy-parcel'
+    const token = 'dummy-defra-id-token'
+
+    const dbAgreements = [
+      {
+        actionCode: 'UPL1',
+        quantity: 100,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-11-31')
+      },
+      {
+        actionCode: 'UPL2',
+        quantity: 10000,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-11-31')
+      }
+    ]
+    const dalAgreements = [
+      {
+        actionCode: 'CMOR1',
+        quantity: 15000,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-11-31')
+      },
+      {
+        actionCode: 'CMOR2',
+        quantity: 17000,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-11-31')
+      }
+    ]
+
+    db.getAgreementsForParcel.mockResolvedValue(dbAgreements)
+    dal.getAgreements.mockResolvedValue(dalAgreements)
+
+    const result = await getAgreements(
+      sbi,
+      sheetId,
+      parcelId,
+      token,
+      null,
+      mockLogger
+    )
+
+    expect(db.getAgreementsForParcel).toHaveBeenCalledWith(
+      sheetId,
+      parcelId,
+      null,
+      mockLogger
+    )
+    expect(dal.getAgreements).toHaveBeenCalledWith(
+      sbi,
+      parcelId,
+      sheetId,
+      token,
+      mockLogger
+    )
+
+    expect(result).toEqual([...dbAgreements, ...dalAgreements])
+  })
+
+  it('should filter out non-area agreements', async () => {
+    const sbi = '012345678'
+    const sheetId = 'dummy-sheet'
+    const parcelId = 'dummy-parcel'
+    const token = 'dummy-defra-id-token'
+
+    const dbAgreementCount = {
+      actionCode: 'AF1',
+      quantity: 800,
+      unit: 'count',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-11-31')
+    }
+
+    const dbAgreementArea = {
+      actionCode: 'UPL1',
+      quantity: 100,
+      unit: 'sqm',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-11-31')
+    }
+
+    const dalAgreementLength = {
+      actionCode: 'SPM4',
+      quantity: 200,
+      unit: 'm',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-11-31')
+    }
+    const dalAgreementArea = {
+      actionCode: 'CMOR1',
+      quantity: 15000,
+      unit: 'sqm',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-11-31')
+    }
+
+    db.getAgreementsForParcel.mockResolvedValue([
+      dbAgreementCount,
+      dbAgreementArea
+    ])
+    dal.getAgreements.mockResolvedValue([dalAgreementLength, dalAgreementArea])
+
+    const result = await getAgreements(
+      sbi,
+      sheetId,
+      parcelId,
+      token,
+      null,
+      mockLogger
+    )
+
+    expect(db.getAgreementsForParcel).toHaveBeenCalledWith(
+      sheetId,
+      parcelId,
+      null,
+      mockLogger
+    )
+    expect(dal.getAgreements).toHaveBeenCalledWith(
+      sbi,
+      parcelId,
+      sheetId,
+      token,
+      mockLogger
+    )
+
+    expect(result).toEqual([dbAgreementArea, dalAgreementArea])
+  })
+})

--- a/src/features/application/controllers/2.0.0/application-validation.controller.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.js
@@ -137,6 +137,13 @@ const runApplicationValidation = async (
   postgresDb,
   { landActions, applicationId, sbi, applicantCrn, requester }
 ) => {
+  const defraIdToken = /** @type {string} */ (
+    request.headers['x-forwarded-authorization']
+  )
+  if (!defraIdToken) {
+    return Boom.unauthorized('X-Forwarded-Authorization is required')
+  }
+
   const actions = await getActions(
     request,
     postgresDb,
@@ -154,10 +161,16 @@ const runApplicationValidation = async (
     return validationError
   }
 
-  const parcelResults = await validateAllLandParcels(request, postgresDb, {
-    landActions,
-    actions
-  })
+  const parcelResults = await validateAllLandParcels(
+    request,
+    postgresDb,
+    sbi,
+    defraIdToken,
+    {
+      landActions,
+      actions
+    }
+  )
 
   const id = await saveValidationResults(request, postgresDb, {
     applicationId,
@@ -290,7 +303,13 @@ const ApplicationValidationController = {
       const validationResult = await runApplicationValidation(
         request,
         postgresDb,
-        { landActions, applicationId, sbi, applicantCrn, requester }
+        {
+          landActions,
+          applicationId,
+          sbi: String(sbi),
+          applicantCrn,
+          requester
+        }
       )
       if (Boom.isBoom(validationResult)) {
         return validationResult

--- a/src/features/application/controllers/2.0.0/application-validation.controller.test.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.test.js
@@ -184,6 +184,7 @@ describe('ApplicationValidationController', () => {
       const sbi = 123456789
       const request = {
         method: 'POST',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         url: '/api/v2/application/validate',
         payload: {
           applicationId,
@@ -245,12 +246,14 @@ describe('ApplicationValidationController', () => {
           landActions: mockLandActions,
           actions: mockActions,
           applicationId,
-          sbi
+          sbi: String(sbi)
         }
       )
       expect(mockValidateAllLandParcels).toHaveBeenCalledWith(
         expect.objectContaining({ logger: expect.any(Object) }),
         mockPostgresDb,
+        String(sbi),
+        'dummy-token',
         { landActions: mockLandActions, actions: mockActions }
       )
     })
@@ -261,6 +264,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId,
           requester: 'test-user',
@@ -304,6 +308,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -328,6 +333,27 @@ describe('ApplicationValidationController', () => {
       )
     })
 
+    test('should return 401 when missing X-Forwarded-Authorization header', async () => {
+      const applicationId = 'APP-123'
+      const sbi = 123456789
+      const request = {
+        method: 'POST',
+        url: '/api/v2/application/validate',
+        payload: {
+          applicationId,
+          requester: 'test-user',
+          applicantCrn: 'CRN-456',
+          sbi,
+          landActions: mockLandActions
+        }
+      }
+
+      /** @type { Hapi.ServerInjectResponse<object> } */
+      const { statusCode } = await server.inject(request)
+
+      expect(statusCode).toBe(401)
+    })
+
     test('should return 400 when validation errors exist', async () => {
       const validationErrors = [
         'Land parcels not found: SX0679-9999',
@@ -338,6 +364,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/applications/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -365,6 +392,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -390,6 +418,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -428,6 +457,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -455,6 +485,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -478,6 +509,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -512,6 +544,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -537,6 +570,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -563,6 +597,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',
@@ -591,6 +626,7 @@ describe('ApplicationValidationController', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
         payload: {
           applicationId: 'APP-123',
           requester: 'test-user',

--- a/src/features/application/service/application-validation.service.js
+++ b/src/features/application/service/application-validation.service.js
@@ -63,7 +63,14 @@ export const validateApplication = async (
   // Validate each land action
   const parcelResults = await Promise.all(
     landAction.map(async (la) =>
-      validateLandParcelActions(la, actions, compatibilityCheckFn, request)
+      validateLandParcelActions(
+        sbi,
+        la,
+        actions,
+        compatibilityCheckFn,
+        request,
+        null
+      )
     )
   )
 

--- a/src/features/application/service/application-validation.service.test.js
+++ b/src/features/application/service/application-validation.service.test.js
@@ -196,17 +196,21 @@ describe('Application Validation Service', () => {
       expect(mockValidateLandParcelActions).toHaveBeenCalledTimes(2)
       expect(mockValidateLandParcelActions).toHaveBeenNthCalledWith(
         1,
+        mockSbi,
         mockLandAction[0],
         mockEnabledActions,
         mockCompatibilityCheckFn,
-        mockRequest
+        mockRequest,
+        null
       )
       expect(mockValidateLandParcelActions).toHaveBeenNthCalledWith(
         2,
+        mockSbi,
         mockLandAction[1],
         mockEnabledActions,
         mockCompatibilityCheckFn,
-        mockRequest
+        mockRequest,
+        null
       )
 
       expect(mockApplicationDataTransformer).toHaveBeenCalledWith(

--- a/src/features/application/service/land-parcel-validation.service.js
+++ b/src/features/application/service/land-parcel-validation.service.js
@@ -1,26 +1,34 @@
-import { getAgreementsForParcel } from '../../agreements/queries/getAgreementsForParcel.query.js'
+import { getAgreements } from '~/src/features/agreements/repo.js'
 import { validateLandAction } from './action-validation.service.js'
 
 /**
  * Validate land parcel actions
+ * @param {string} sbi - The SBI for the business
  * @param {object} landAction - The land action requested for validation
  * @param {object} actions - The actions
  * @param {object} compatibilityCheckFn - The compatibility check function
  * @param {object} request - The request
+ * @param {string|null} defraIdToken - The JWT token for the end user in DEFRA ID
  */
 export const validateLandParcelActions = async (
+  sbi,
   landAction,
   actions,
   compatibilityCheckFn,
-  request
+  request,
+  defraIdToken
 ) => {
   if (!landAction || !actions || !compatibilityCheckFn) {
     throw new Error('Unable to validate land parcel actions')
   }
 
-  const agreements = await getAgreementsForParcel(
+  // Get agreements and filter them to only area-based actions, as only
+  // these should be used for Available Area Calculations
+  const agreements = await getAgreements(
+    sbi,
     landAction.sheetId,
     landAction.parcelId,
+    defraIdToken,
     request.server.postgresDb,
     request.logger
   )

--- a/src/features/application/service/land-parcel-validation.service.test.js
+++ b/src/features/application/service/land-parcel-validation.service.test.js
@@ -1,14 +1,20 @@
-import { validateLandParcelActions } from './land-parcel-validation.service.js'
-import { getAgreementsForParcel } from '../../agreements/queries/getAgreementsForParcel.query.js'
-import { validateLandAction } from './action-validation.service.js'
-import { mockActionConfig } from '~/src/features/actions/fixtures/index.js'
 import { vi } from 'vitest'
 
+import { getAgreements } from '~/src/services/dal/index.js'
+import { getAgreementsForParcel } from '../../agreements/queries/getAgreementsForParcel.query.js'
+import { mockActionConfig } from '~/src/features/actions/fixtures/index.js'
+import { validateLandAction } from './action-validation.service.js'
+import { validateLandParcelActions } from './land-parcel-validation.service.js'
+
 vi.mock('../../agreements/queries/getAgreementsForParcel.query.js')
+vi.mock('~/src/services/dal/index.js')
 vi.mock('./action-validation.service.js')
 
 const mockGetAgreementsForParcel = getAgreementsForParcel
+const mockGetAgreements = getAgreements
 const mockValidateLandAction = validateLandAction
+
+const sbi = '012345678'
 
 describe('Land Parcel Validation Service', () => {
   const mockLogger = {
@@ -23,6 +29,7 @@ describe('Land Parcel Validation Service', () => {
   }
 
   const mockRequest = {
+    headers: { 'x-forwarded-authorization': 'dummy-token' },
     logger: mockLogger,
     server: {
       postgresDb: mockPostgresDb
@@ -48,12 +55,25 @@ describe('Land Parcel Validation Service', () => {
 
   const mockCompatibilityCheckFn = vi.fn()
 
-  const mockAgreements = [
+  const mockAgreementsDb = [
     {
-      code: 'LIG2',
-      area: 100
+      actionCode: 'CLIG2',
+      quantity: 100,
+      unit: 'sqm',
+      startDate: new Date('2020-01-01T00:00:00Z'),
+      endDate: new Date('2030-01-01T00:00:00Z')
     }
   ]
+  const mockAgreementsDal = [
+    {
+      actionCode: 'CLIG2',
+      quantity: 1000,
+      unit: 'sqm',
+      startDate: new Date('2020-01-01T00:00:00Z'),
+      endDate: new Date('2030-01-01T00:00:00Z')
+    }
+  ]
+  const mockAgreementsAll = [...mockAgreementsDb, ...mockAgreementsDal]
 
   const mockActionResult1 = {
     hasPassed: true,
@@ -92,7 +112,8 @@ describe('Land Parcel Validation Service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockGetAgreementsForParcel.mockResolvedValue(mockAgreements)
+    mockGetAgreementsForParcel.mockResolvedValue(mockAgreementsDb)
+    mockGetAgreements.mockResolvedValue(mockAgreementsDal)
     mockValidateLandAction.mockResolvedValue(mockActionResult1)
   })
 
@@ -103,10 +124,12 @@ describe('Land Parcel Validation Service', () => {
         .mockResolvedValueOnce(mockActionResult2)
 
       const result = await validateLandParcelActions(
+        sbi,
         mockLandAction,
         mockActions,
         mockCompatibilityCheckFn,
-        mockRequest
+        mockRequest,
+        'dummy-token'
       )
 
       expect(result).toEqual({
@@ -121,13 +144,20 @@ describe('Land Parcel Validation Service', () => {
         mockPostgresDb,
         mockLogger
       )
+      expect(mockGetAgreements).toHaveBeenCalledWith(
+        sbi,
+        mockLandAction.parcelId,
+        mockLandAction.sheetId,
+        'dummy-token',
+        mockLogger
+      )
 
       expect(mockValidateLandAction).toHaveBeenCalledTimes(2)
       expect(mockValidateLandAction).toHaveBeenNthCalledWith(
         1,
         mockLandAction.actions[0],
         mockActions,
-        mockAgreements,
+        mockAgreementsAll,
         mockCompatibilityCheckFn,
         mockLandAction,
         mockRequest
@@ -136,7 +166,7 @@ describe('Land Parcel Validation Service', () => {
         2,
         mockLandAction.actions[1],
         mockActions,
-        mockAgreements,
+        mockAgreementsAll,
         mockCompatibilityCheckFn,
         mockLandAction,
         mockRequest
@@ -146,10 +176,12 @@ describe('Land Parcel Validation Service', () => {
     test('should throw error when landAction is null', async () => {
       await expect(
         validateLandParcelActions(
+          sbi,
           null,
           mockActions,
           mockCompatibilityCheckFn,
-          mockRequest
+          mockRequest,
+          'dummy-token'
         )
       ).rejects.toThrow('Unable to validate land parcel actions')
     })
@@ -157,10 +189,12 @@ describe('Land Parcel Validation Service', () => {
     test('should throw error when actions is null', async () => {
       await expect(
         validateLandParcelActions(
+          sbi,
           mockLandAction,
           null,
           mockCompatibilityCheckFn,
-          mockRequest
+          mockRequest,
+          'dummy-token'
         )
       ).rejects.toThrow('Unable to validate land parcel actions')
     })
@@ -168,31 +202,72 @@ describe('Land Parcel Validation Service', () => {
     test('should throw error when compatibilityCheckFn is null', async () => {
       await expect(
         validateLandParcelActions(
+          sbi,
           mockLandAction,
           mockActions,
           null,
-          mockRequest
+          mockRequest,
+          'dummy-token'
         )
       ).rejects.toThrow('Unable to validate land parcel actions')
     })
 
-    test('should handle database errors when fetching agreements', async () => {
+    test('should fail if database error occurs when fetching agreements', async () => {
       const dbError = new Error('Database connection failed')
       mockGetAgreementsForParcel.mockRejectedValue(dbError)
 
       await expect(
         validateLandParcelActions(
+          sbi,
           mockLandAction,
           mockActions,
           mockCompatibilityCheckFn,
-          mockRequest
+          mockRequest,
+          'dummy-token'
         )
-      ).rejects.toThrow('Database connection failed')
+      ).rejects.toThrow()
 
       expect(mockGetAgreementsForParcel).toHaveBeenCalledWith(
         mockLandAction.sheetId,
         mockLandAction.parcelId,
         mockPostgresDb,
+        mockLogger
+      )
+      expect(mockGetAgreements).toHaveBeenCalledWith(
+        sbi,
+        mockLandAction.parcelId,
+        mockLandAction.sheetId,
+        'dummy-token',
+        mockLogger
+      )
+    })
+
+    test('should fail if fetching agreements from DAL fails', async () => {
+      const err = new Error('DAL request failed')
+      mockGetAgreements.mockRejectedValue(err)
+
+      await expect(
+        validateLandParcelActions(
+          sbi,
+          mockLandAction,
+          mockActions,
+          mockCompatibilityCheckFn,
+          mockRequest,
+          'dummy-token'
+        )
+      ).rejects.toThrow()
+
+      expect(mockGetAgreementsForParcel).toHaveBeenCalledWith(
+        mockLandAction.sheetId,
+        mockLandAction.parcelId,
+        mockPostgresDb,
+        mockLogger
+      )
+      expect(mockGetAgreements).toHaveBeenCalledWith(
+        sbi,
+        mockLandAction.parcelId,
+        mockLandAction.sheetId,
+        'dummy-token',
         mockLogger
       )
     })

--- a/src/features/application/service/validation.service.js
+++ b/src/features/application/service/validation.service.js
@@ -39,6 +39,8 @@ export const validateRequestData = async (
  * Validate all land parcel actions
  * @param {import('@hapi/hapi').Request} request
  * @param {object} postgresDb
+ * @param {string} sbi
+ * @param {string|null} defraIdToken
  * @param {object} data
  * @param {Array} data.landActions
  * @param {Array} data.actions
@@ -47,6 +49,8 @@ export const validateRequestData = async (
 export const validateAllLandParcels = async (
   request,
   postgresDb,
+  sbi,
+  defraIdToken,
   { landActions, actions }
 ) => {
   const compatibilityCheckFn = await createCompatibilityMatrix(
@@ -57,10 +61,12 @@ export const validateAllLandParcels = async (
   const parcelResults = await Promise.all(
     landActions.map(async (landAction) => {
       return validateLandParcelActions(
+        sbi,
         landAction,
         actions,
         compatibilityCheckFn,
-        request
+        request,
+        defraIdToken
       )
     })
   )

--- a/src/features/application/service/validation.service.test.js
+++ b/src/features/application/service/validation.service.test.js
@@ -106,6 +106,8 @@ describe('Validation Service', () => {
 
   describe('validateAllLandParcels', () => {
     test('should return an array of parcel results when validation passes', async () => {
+      const sbi = '012345678'
+      const defraIdToken = 'dummy'
       const mockParcelResult1 = { sheetId: 'SX0679', parcelId: '9238' }
       const mockParcelResult2 = { sheetId: 'SX0680', parcelId: '9239' }
       const mockLandActionsForTest = [
@@ -118,10 +120,16 @@ describe('Validation Service', () => {
         .mockResolvedValueOnce(mockParcelResult1)
         .mockResolvedValueOnce(mockParcelResult2)
 
-      const result = await validateAllLandParcels(mockRequest, mockPostgresDb, {
-        landActions: mockLandActionsForTest,
-        actions: mockActions
-      })
+      const result = await validateAllLandParcels(
+        mockRequest,
+        mockPostgresDb,
+        sbi,
+        defraIdToken,
+        {
+          landActions: mockLandActionsForTest,
+          actions: mockActions
+        }
+      )
 
       expect(result).toEqual([mockParcelResult1, mockParcelResult2])
       expect(mockCreateCompatibilityMatrix).toHaveBeenCalledWith(
@@ -131,17 +139,21 @@ describe('Validation Service', () => {
       expect(mockValidateLandParcelActions).toHaveBeenCalledTimes(2)
       expect(mockValidateLandParcelActions).toHaveBeenNthCalledWith(
         1,
+        sbi,
         mockLandActionsForTest[0],
         mockActions,
         mockCompatibilityCheckFn,
-        mockRequest
+        mockRequest,
+        defraIdToken
       )
       expect(mockValidateLandParcelActions).toHaveBeenNthCalledWith(
         2,
+        sbi,
         mockLandActionsForTest[1],
         mockActions,
         mockCompatibilityCheckFn,
-        mockRequest
+        mockRequest,
+        defraIdToken
       )
     })
   })

--- a/src/features/parcel/controllers/2.0.0/parcels.controller.js
+++ b/src/features/parcel/controllers/2.0.0/parcels.controller.js
@@ -99,6 +99,11 @@ const ParcelsControllerV2 = {
         }
       })
 
+      const defraIdToken = request.headers['x-forwarded-authorization']
+      if (!defraIdToken) {
+        return Boom.unauthorized('X-Forwarded-Authorization is required')
+      }
+
       const sssiConsentRequiredError = validateSSSIConsentRequired(
         parcelIds,
         fields
@@ -147,7 +152,8 @@ const ParcelsControllerV2 = {
             showActionResults,
             validationResponse.enabledActions,
             compatibilityCheckFn,
-            request
+            request,
+            defraIdToken
           )
         })
       )

--- a/src/features/parcel/controllers/2.0.0/parcels.controller.test.js
+++ b/src/features/parcel/controllers/2.0.0/parcels.controller.test.js
@@ -1,13 +1,14 @@
-import { parcel } from '~/src/features/parcel/index.js'
+import { vi } from 'vitest'
+
+import createTestServer from '~/src/tests/test-server.js'
+import { createCompatibilityMatrix } from '~/src/features/available-area/compatibilityMatrix.js'
 import {
   getActionsForParcel,
   getActionsForParcelWithSSSIConsentRequired,
   getActionsForParcelWithHEFERConsentRequired
 } from '~/src/features/parcel/service/2.0.0/parcel.service.js'
-import { createCompatibilityMatrix } from '~/src/features/available-area/compatibilityMatrix.js'
 import { getDataAndValidateRequest } from '~/src/features/parcel/validation/2.0.0/parcel.validation.js'
-import { vi } from 'vitest'
-import createTestServer from '~/src/tests/test-server.js'
+import { parcel } from '~/src/features/parcel/index.js'
 
 vi.mock('~/src/features/parcel/validation/2.0.0/parcel.validation.js')
 vi.mock('~/src/features/parcel/service/2.0.0/parcel.service.js')
@@ -20,6 +21,8 @@ const mockGetActionsForParcelWithSSSIConsentRequired =
 const mockGetActionsForParcelWithHEFERConsentRequired =
   getActionsForParcelWithHEFERConsentRequired
 const mockCreateCompatibilityMatrix = createCompatibilityMatrix
+
+const sbi = '012345678'
 
 const mockParcelData = {
   sheet_id: 'SX0679',
@@ -160,7 +163,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['size']
         }
@@ -199,7 +204,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -261,7 +268,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions.results']
         }
@@ -286,7 +295,8 @@ describe('Parcels Controller 2.0.0', () => {
         true, // showActionResults should be true
         mockEnabledActions,
         expect.any(Function),
-        expect.anything()
+        expect.anything(),
+        'dummy'
       )
       expect(
         mockGetActionsForParcelWithSSSIConsentRequired
@@ -300,7 +310,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions', 'actions.sssiConsentRequired']
         }
@@ -341,7 +353,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238', 'SX0679-9239'],
           fields: ['actions', 'actions.sssiConsentRequired']
         }
@@ -368,7 +382,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -387,11 +403,27 @@ describe('Parcels Controller 2.0.0', () => {
       ).not.toHaveBeenCalled()
     })
 
-    test('should return 200 and call getActionsForParcelWithHEFERConsentRequired when requesting actions.heferRequired', async () => {
+    test('should return 401 when defra ID token not provided', async () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
         payload: {
+          sbi,
+          parcelIds: ['SX0679-9238'],
+          fields: ['actions']
+        }
+      }
+      const response = await server.inject(request)
+      expect(response.statusCode).toBe(401)
+    })
+
+    test('should return 200 and call getActionsForParcelWithHEFERConsentRequired when requesting actions.heferRequired', async () => {
+      const request = {
+        method: 'POST',
+        url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
+        payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions', 'actions.heferRequired']
         }
@@ -432,7 +464,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -455,7 +489,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238', 'SX0679-9239'],
           fields: ['actions', 'actions.heferRequired']
         }
@@ -482,7 +518,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: [
             'actions',
@@ -538,7 +576,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions'],
           plannedActions: [
@@ -575,7 +615,8 @@ describe('Parcels Controller 2.0.0', () => {
         false,
         mockEnabledActions,
         expect.any(Function),
-        expect.anything()
+        expect.anything(),
+        'dummy'
       )
     })
 
@@ -632,7 +673,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -654,7 +697,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['groups']
         }
@@ -678,7 +723,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['size']
         }
@@ -701,7 +748,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9999'],
           fields: ['size']
         }
@@ -727,7 +776,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9999'],
           fields: ['size']
         }
@@ -749,7 +800,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           fields: ['size']
         }
       }
@@ -768,7 +821,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238']
         }
       }
@@ -787,7 +842,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['invalid-parcel-id'],
           fields: ['size']
         }
@@ -809,7 +866,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['invalid-field']
         }
@@ -831,7 +890,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions'],
           plannedActions: [
@@ -857,7 +918,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions'],
           plannedActions: [
@@ -888,7 +951,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -912,7 +977,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -936,7 +1003,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions', 'actions.sssiConsentRequired']
         }
@@ -960,7 +1029,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions', 'actions.heferRequired']
         }
@@ -984,7 +1055,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -1008,7 +1081,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['size']
         }
@@ -1028,7 +1103,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -1046,7 +1123,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -1063,7 +1142,8 @@ describe('Parcels Controller 2.0.0', () => {
         false,
         mockEnabledActions,
         expect.any(Function),
-        expect.anything()
+        expect.anything(),
+        'dummy'
       )
     })
 
@@ -1071,7 +1151,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions'],
           plannedActions: []
@@ -1112,7 +1194,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['actions']
         }
@@ -1153,7 +1237,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['size']
         }
@@ -1180,7 +1266,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9999'],
           fields: ['size']
         }
@@ -1199,7 +1287,9 @@ describe('Parcels Controller 2.0.0', () => {
       const request = {
         method: 'POST',
         url: '/api/v2/parcels',
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         payload: {
+          sbi,
           parcelIds: ['SX0679-9238'],
           fields: ['size']
         }

--- a/src/features/parcel/schema/2.0.0/parcel.schema.js
+++ b/src/features/parcel/schema/2.0.0/parcel.schema.js
@@ -35,7 +35,7 @@ const parcelSchema = Joi.object({
 })
 
 const parcelsSchema = Joi.object({
-  sbi: Joi.string().optional(),
+  sbi: Joi.string().required(),
   parcelIds: Joi.array().items(parcelIdSchema).required(),
   fields: Joi.array()
     .items(

--- a/src/features/parcel/schema/2.0.0/parcel.schema.test.js
+++ b/src/features/parcel/schema/2.0.0/parcel.schema.test.js
@@ -134,12 +134,6 @@ describe('Parcel Schema Validation v2', () => {
       expect(result.error).toBeUndefined()
     })
 
-    it('should allow missing SBI', () => {
-      const valid = { ...validParcelsRequest, sbi: undefined }
-      const result = parcelsSchema.validate(valid)
-      expect(result.error).toBeUndefined()
-    })
-
     it('should reject invalid parcel ID format', () => {
       const invalid = {
         ...validParcelsRequest,

--- a/src/features/parcel/service/2.0.0/parcel.service.js
+++ b/src/features/parcel/service/2.0.0/parcel.service.js
@@ -1,27 +1,27 @@
-import { getAvailableAreaDataRequirements } from '~/src/features/available-area/availableAreaDataRequirements.js'
+import {
+  DATA_LAYER_TYPES,
+  getDataLayerQueryAccumulated,
+  getDataLayerQueryUnion
+} from '~/src/features/data-layers/queries/getDataLayer.query.js'
+import { actionTransformer } from '~/src/features/parcel/transformers/2.0.0/parcelActions.transformer.js'
+import { executeSingleRuleForEnabledActions } from '~/src/features/rules-engine/rulesEngine.js'
 import {
   findMaximumAvailableArea,
   throwIfInfeasible
 } from '~/src/features/available-area/availableArea.js'
 import { formatExplanationSections } from '~/src/features/available-area/explanations.js'
+import { getAgreements } from '~/src/features/agreements/repo.js'
+import { getAvailableAreaDataRequirements } from '~/src/features/available-area/availableAreaDataRequirements.js'
+import { heferConsentRequired } from '~/src/features/rules-engine/rules/1.0.0/hefer-consent-required.js'
 import {
   heferRequiredActionTransformer,
   plannedActionsTransformer,
   sizeTransformer,
   sssiConsentRequiredActionTransformer
 } from '~/src/features/parcel/transformers/parcelActions.transformer.js'
-import { actionTransformer } from '~/src/features/parcel/transformers/2.0.0/parcelActions.transformer.js'
-import { sqmToHaRounded } from '~/src/features/common/helpers/measurement.js'
-import { getAgreementsForParcel } from '~/src/features/agreements/queries/getAgreementsForParcel.query.js'
 import { mergeAgreementsTransformer } from '~/src/features/agreements/transformers/agreements.transformer.js'
-import {
-  DATA_LAYER_TYPES,
-  getDataLayerQueryAccumulated,
-  getDataLayerQueryUnion
-} from '~/src/features/data-layers/queries/getDataLayer.query.js'
-import { executeSingleRuleForEnabledActions } from '~/src/features/rules-engine/rulesEngine.js'
+import { sqmToHaRounded } from '~/src/features/common/helpers/measurement.js'
 import { sssiConsentRequired } from '~/src/features/rules-engine/rules/1.0.0/sssi-consent-required.js'
-import { heferConsentRequired } from '~/src/features/rules-engine/rules/1.0.0/hefer-consent-required.js'
 
 /**
  * @import {LandParcelDb} from '~/src/features/parcel/parcel.d.js'
@@ -128,9 +128,10 @@ export async function getActionsForParcel(
   showActionResults,
   enabledActions,
   compatibilityCheckFn,
-  request
+  request,
+  defraIdToken
 ) {
-  const { fields, plannedActions } = payload
+  const { fields, plannedActions, sbi } = payload
 
   const parcelResponse = {
     parcelId: parcel.parcel_id,
@@ -142,9 +143,11 @@ export async function getActionsForParcel(
   }
 
   if (fields.some((f) => f.startsWith('actions'))) {
-    const agreements = await getAgreementsForParcel(
+    const agreements = await getAgreements(
+      sbi,
       parcel.sheet_id,
       parcel.parcel_id,
+      defraIdToken,
       request.server.postgresDb,
       request.logger
     )

--- a/src/features/parcel/transformers/parcelActions.transformer.test.js
+++ b/src/features/parcel/transformers/parcelActions.transformer.test.js
@@ -244,6 +244,14 @@ describe('plannedActionsTransformer', () => {
 
     expect(result).toEqual([])
   })
+
+  test('should transform current actions to actions when area is already sqm', () => {
+    const plannedActions = [{ actionCode: 'UPL1', quantity: 1000, unit: 'sqm' }]
+
+    const result = plannedActionsTransformer(plannedActions)
+
+    expect(result).toEqual([{ actionCode: 'UPL1', areaSqm: 1000 }])
+  })
 })
 
 describe('sssiConsentRequiredActionTransformer', () => {

--- a/src/services/dal/index.js
+++ b/src/services/dal/index.js
@@ -1,14 +1,35 @@
 import { GET_BUSINESS } from './queries.js'
 import { config } from '~/src/config/index.js'
 import { dalBusinessToAgreements } from '~/src/features/agreements/transformers/agreements.transformer.js'
+import { logInfo } from '~/src/features/common/helpers/logging/log-helpers.js'
 import { proxyFetch } from '~/src/features/common/helpers/proxy.js'
 
 /**
  * Fetches existing Siti Agri agreements for a business from the DAL
  * @param {string} sbi - Single Business Identifier
+ * @param {string} parcelId - The parcel ID to filter results by
+ * @param {string} sheetId - The sheet ID to filter results by
+ * @param {string|null} defraIdToken - The external user token to use for auth (if null, use s2s auth)
+ * @param {Logger} logger - Logger object
  * @returns {Promise<AgreementAction[]>} The existing agreements for the sbi
  */
-export async function getAgreements(sbi, parcelId, sheetId, defraIdToken) {
+export async function getAgreements(
+  sbi,
+  parcelId,
+  sheetId,
+  defraIdToken,
+  logger
+) {
+  // TODO(GSPS-504): In this case we should authenticate differently with the DAL and use service
+  // to service auth; this is not yet available so we'll return no results until implemented
+  if (defraIdToken === null) {
+    return Promise.resolve([])
+  }
+
+  if (!config.get('featureFlags.useDal')) {
+    return Promise.resolve([])
+  }
+
   const endpoint = config.get('dal.apiEndpoint')
 
   const response = await proxyFetch(endpoint, {
@@ -22,15 +43,34 @@ export async function getAgreements(sbi, parcelId, sheetId, defraIdToken) {
   })
 
   if (!response.ok) {
+    if (response.status === 404) {
+      return Promise.resolve([])
+    }
+
     throw new Error(
       `Failed to fetch existing DAL agreements for sbi=${sbi}: ${response.status} ${response.statusText}`
     )
   }
 
   const body = await response.json()
-  return dalBusinessToAgreements(body.data.business, parcelId, sheetId)
+  const results = dalBusinessToAgreements(body.data.business, parcelId, sheetId)
+
+  const summary = results.map(
+    (a) =>
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      `${a.actionCode}: ${a.quantity} ${a.unit}, ${a.startDate}-${a.endDate}`
+  )
+  logInfo(logger, {
+    category: 'agreements',
+    operation: 'Fetch agreements from DAL',
+    context: { parcelId, sheetId, sbi },
+    message: `Retrieved ${results.length} agreements: [${summary.join(', ')}]`
+  })
+
+  return results
 }
 
 /**
  * @import { AgreementAction } from '~/src/features/agreements/agreements.d.js'
+ * @import {Logger} from '~/src/features/common/logger.d.js'
  */

--- a/src/services/dal/index.test.js
+++ b/src/services/dal/index.test.js
@@ -13,16 +13,30 @@ vi.mock('~/src/features/common/helpers/proxy.js')
 
 const stubEndpoint = 'http://stub-dal/graphql'
 const dalResponse = { data: { business: SIMPLE_BUSINESS } }
+const response404 = {
+  errors: [
+    {
+      message: 'Rural payments organisation not found',
+      locations: [{ line: 1, column: 32 }],
+      path: ['business'],
+      extensions: { code: 'NOT FOUND' }
+    }
+  ]
+}
+
+const mockLogger = { info: vi.fn() }
 
 describe('getAgreements', () => {
   const sbi = '123456789'
 
   afterEach(() => {
     config.set('dal.apiEndpoint', config.default('dal.apiEndpoint'))
+    config.set('featureFlags.useDal', config.default('featureFlags.useDal'))
   })
 
   beforeEach(() => {
     config.set('dal.apiEndpoint', stubEndpoint)
+    config.set('featureFlags.useDal', true)
     vi.clearAllMocks()
   })
 
@@ -32,7 +46,13 @@ describe('getAgreements', () => {
       json: () => Promise.resolve(dalResponse)
     })
 
-    const result = await getAgreements(sbi, PARCEL_ID, SHEET_ID, 'dummy')
+    const result = await getAgreements(
+      sbi,
+      PARCEL_ID,
+      SHEET_ID,
+      'dummy',
+      mockLogger
+    )
 
     expect(proxy.proxyFetch).toHaveBeenCalledWith(
       stubEndpoint,
@@ -59,7 +79,53 @@ describe('getAgreements', () => {
     })
 
     await expect(
-      getAgreements(sbi, PARCEL_ID, SHEET_ID, 'dummy')
+      getAgreements(sbi, PARCEL_ID, SHEET_ID, 'dummy', mockLogger)
     ).rejects.toThrow()
+  })
+
+  it('returns an empty array when DAL 404s', async () => {
+    proxy.proxyFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.resolve(response404)
+    })
+    const result = await getAgreements(
+      sbi,
+      PARCEL_ID,
+      SHEET_ID,
+      'dummy',
+      mockLogger
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty array when feature flag is off', async () => {
+    config.set('featureFlags.useDal', false)
+    const result = await getAgreements(
+      sbi,
+      PARCEL_ID,
+      SHEET_ID,
+      'dummy',
+      mockLogger
+    )
+
+    expect(proxy.proxyFetch).not.toBeCalled()
+    expect(result).toEqual([])
+  })
+
+  // TODO: replace with service-to-service auth in this scenario
+  it('returns an empty array when missing a defra ID token', async () => {
+    const result = await getAgreements(
+      sbi,
+      PARCEL_ID,
+      SHEET_ID,
+      null,
+      mockLogger
+    )
+
+    expect(proxy.proxyFetch).not.toBeCalled()
+    expect(result).toEqual([])
   })
 })

--- a/src/tests/contract-tests/provider.test.js
+++ b/src/tests/contract-tests/provider.test.js
@@ -1,33 +1,34 @@
+import dotenv from 'dotenv'
 import { env } from 'node:process'
 
-import dotenv from 'dotenv'
+import createTestServer from '../test-server.js'
 import { Verifier } from '@pact-foundation/pact'
-import { getLandData } from '~/src/features/parcel/queries/getLandData.query.js'
+import { application } from '~/src/features/application/index.js'
+import { applicationValidationRunToCaseManagement } from '~/src/features/case-management-adapter/transformers/application-validation.transformer.js'
+import { caseManagementAdapter } from '~/src/features/case-management-adapter/index.js'
+import { config } from '~/src/config/index.js'
+import { createCompatibilityMatrix } from '~/src/features/available-area/compatibilityMatrix.js'
+import { findMaximumAvailableArea } from '~/src/features/available-area/availableArea.js'
+import { formatExplanationSections } from '~/src/features/available-area/explanations.js'
+import { getActionsByLatestVersion } from '~/src/features/actions/queries/2.0.0/getActionsByLatestVersion.query.js'
+import { getActionsByVersion } from '~/src/features/actions/queries/2.0.0/getActionsByVersion.query.js'
 import { getAgreementsForParcel } from '~/src/features/agreements/queries/getAgreementsForParcel.query.js'
+import { getApplicationValidationRun } from '~/src/features/application/queries/getApplicationValidationRun.query.js'
+import { getAvailableAreaDataRequirements } from '~/src/features/available-area/availableAreaDataRequirements.js'
+import { getEnabledActions } from '~/src/features/actions/queries/getEnabledActions.query.js'
+import { getLandData } from '~/src/features/parcel/queries/getLandData.query.js'
+import { getLatestVersion } from './git.js'
+import { logger } from '~/src/tests/db-tests/setup/testLogger.js'
 import {
   mockActionConfig,
   mockWoodlandManagementActionConfig
 } from '~/src/features/actions/fixtures/index.js'
 import { parcel } from '~/src/features/parcel/index.js'
 import { payments } from '~/src/features/payment/index.js'
-import { application } from '~/src/features/application/index.js'
-import { woodlandManagement } from '~/src/features/woodland-management/index.js'
-import { caseManagementAdapter } from '~/src/features/case-management-adapter/index.js'
-import { getAvailableAreaDataRequirements } from '~/src/features/available-area/availableAreaDataRequirements.js'
-import { findMaximumAvailableArea } from '~/src/features/available-area/availableArea.js'
-import { formatExplanationSections } from '~/src/features/available-area/explanations.js'
-import { createCompatibilityMatrix } from '~/src/features/available-area/compatibilityMatrix.js'
-import { logger } from '~/src/tests/db-tests/setup/testLogger.js'
-import { getEnabledActions } from '~/src/features/actions/queries/getEnabledActions.query.js'
-import { getActionsByLatestVersion } from '~/src/features/actions/queries/2.0.0/getActionsByLatestVersion.query.js'
-import { getActionsByVersion } from '~/src/features/actions/queries/2.0.0/getActionsByVersion.query.js'
 import { saveApplication } from '~/src/features/application/mutations/saveApplication.mutation.js'
-import { getLatestVersion } from './git.js'
-import { getApplicationValidationRun } from '~/src/features/application/queries/getApplicationValidationRun.query.js'
-import { applicationValidationRunToCaseManagement } from '~/src/features/case-management-adapter/transformers/application-validation.transformer.js'
-import { validateApplication } from '~/src/features/application/service/application-validation.service.js'
 import { splitParcelId } from '~/src/features/parcel/service/2.0.0/parcel.service.js'
-import createTestServer from '../test-server.js'
+import { validateApplication } from '~/src/features/application/service/application-validation.service.js'
+import { woodlandManagement } from '~/src/features/woodland-management/index.js'
 
 vi.mock('~/src/features/parcel/queries/getLandData.query.js')
 vi.mock('~/src/features/actions/queries/getEnabledActions.query.js')
@@ -228,6 +229,7 @@ describe('Pact Verification', () => {
   const server = createTestServer()
 
   beforeAll(async () => {
+    config.set('featureFlags.useDal', false)
     server.decorate('request', 'logger', logger)
     server.decorate('server', 'postgresDb', {
       connect: vi.fn(),
@@ -245,6 +247,7 @@ describe('Pact Verification', () => {
   })
 
   afterAll(async () => {
+    config.set('featureFlags.useDal', config.default('featureFlags.useDal'))
     await server.stop()
   })
 

--- a/src/tests/db-tests/2.0.0/controllers/parcelsController.db.test.js
+++ b/src/tests/db-tests/2.0.0/controllers/parcelsController.db.test.js
@@ -1,13 +1,16 @@
 import { ParcelsControllerV2 } from '~/src/features/parcel/controllers/2.0.0/parcels.controller.js'
+import { actions } from '~/src/tests/db-tests/fixtures/actions.js'
 import { connectToTestDatabase } from '~/src/tests/db-tests/setup/postgres.js'
 import { createResponseCapture } from '~/src/tests/db-tests/setup/utils.js'
-import { logger } from '~/src/tests/db-tests/setup/testLogger.js'
-import { actions } from '~/src/tests/db-tests/fixtures/actions.js'
 import { getActionsByLatestVersion } from '~/src/features/actions/queries/2.0.0/getActionsByLatestVersion.query.js'
+import { getAgreements } from '~/src/services/dal/index.js'
+import { logger } from '~/src/tests/db-tests/setup/testLogger.js'
 
+vi.mock('~/src/services/dal/index.js')
 vi.mock(
   '~/src/features/actions/queries/2.0.0/getActionsByLatestVersion.query.js'
 )
+const mockGetAgreements = getAgreements
 const mockGetEnabledActions = getActionsByLatestVersion
 
 describe('Parcels Controller 2.0.0', () => {
@@ -22,6 +25,7 @@ describe('Parcels Controller 2.0.0', () => {
   })
 
   beforeEach(() => {
+    mockGetAgreements.mockResolvedValue([])
     mockGetEnabledActions.mockResolvedValue(actions)
   })
 
@@ -35,6 +39,7 @@ describe('Parcels Controller 2.0.0', () => {
           fields: ['groups'],
           plannedActions: []
         },
+        headers: { 'x-forwarded-authorization': 'dummy' },
         logger,
         server: {
           postgresDb: connection
@@ -65,6 +70,7 @@ describe('Parcels Controller 2.0.0', () => {
           fields: ['size'],
           plannedActions: []
         },
+        headers: { 'x-forwarded-authorization': 'dummy' },
         logger,
         server: {
           postgresDb: connection
@@ -93,6 +99,7 @@ describe('Parcels Controller 2.0.0', () => {
           ],
           plannedActions: []
         },
+        headers: { 'x-forwarded-authorization': 'dummy' },
         logger,
         server: {
           postgresDb: connection

--- a/src/tests/db-tests/controllers/applicationValidationController.db.test.js
+++ b/src/tests/db-tests/controllers/applicationValidationController.db.test.js
@@ -1,12 +1,16 @@
-import { connectToTestDatabase } from '~/src/tests/db-tests/setup/postgres.js'
-import { createResponseCapture } from '~/src/tests/db-tests/setup/utils.js'
-import { ApplicationValidationController } from '~/src/features/application/controllers/2.0.0/application-validation.controller.js'
-import { getApplicationValidationRun } from '~/src/features/application/queries/getApplicationValidationRun.query.js'
-import { auditEvent } from '~/src/features/common/helpers/audit-event.js'
 import { vi } from 'vitest'
 
+import { ApplicationValidationController } from '~/src/features/application/controllers/2.0.0/application-validation.controller.js'
+import { auditEvent } from '~/src/features/common/helpers/audit-event.js'
+import { connectToTestDatabase } from '~/src/tests/db-tests/setup/postgres.js'
+import { createResponseCapture } from '~/src/tests/db-tests/setup/utils.js'
+import { getAgreements } from '~/src/services/dal/index.js'
+import { getApplicationValidationRun } from '~/src/features/application/queries/getApplicationValidationRun.query.js'
+
+vi.mock('~/src/services/dal/index.js')
 vi.mock('~/src/features/common/helpers/audit-event.js')
 
+const mockGetAgreements = getAgreements
 const mockAuditEvent = auditEvent
 
 describe('Application Validation Controller', () => {
@@ -23,6 +27,7 @@ describe('Application Validation Controller', () => {
   })
 
   beforeEach(() => {
+    mockGetAgreements.mockResolvedValue([])
     mockAuditEvent.mockResolvedValue(undefined)
   })
 
@@ -57,6 +62,7 @@ describe('Application Validation Controller', () => {
             }
           ]
         },
+        headers: { 'x-forwarded-authorization': 'dummy' },
         logger,
         server: {
           postgresDb: connection
@@ -65,6 +71,7 @@ describe('Application Validation Controller', () => {
       h
     )
     const { data, statusCode } = getResponse()
+    expect(statusCode).toBe(200)
 
     const applicationResult = await getApplicationValidationRun(
       logger,
@@ -72,7 +79,6 @@ describe('Application Validation Controller', () => {
       data.id
     )
 
-    expect(statusCode).toBe(200)
     expect(data.message).toBe('Application validated successfully')
     expect(data.valid).toBe(false)
     expect(applicationResult).toMatchObject({

--- a/src/tests/e2e-tests/application.e2e.test.js
+++ b/src/tests/e2e-tests/application.e2e.test.js
@@ -2,11 +2,16 @@ import { describe, test, expect } from 'vitest'
 import { httpClient } from './setup/http-client.js'
 import { getAuthHeader } from './setup/auth-helpers.js'
 
+const headers = {
+  Authorization: getAuthHeader(),
+  'X-Forwarded-Authorization': 'dummy'
+}
+
 describe('Application Validation Endpoints', () => {
   describe('POST /api/v2/application/validate', () => {
     test('should validate application with authentication', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: 'appid-1',
           requester: 'test-user',
@@ -38,6 +43,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should return 401 without authentication', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
+        headers: { 'X-Forwarded-Authorization': 'dummy' },
         body: {
           applicationId: 'appid-2',
           requester: 'test-user',
@@ -63,7 +69,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should return 400 for missing required fields', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: 'appid-3',
           requester: 'test-user'
@@ -75,7 +81,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should return 422 for negative quantity', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: 'appid-5',
           requester: 'test-user',
@@ -101,7 +107,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should validate multiple parcels with multiple actions', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: 'appid-6',
           requester: 'test-user',
@@ -147,7 +153,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should create validation run for retrieval test', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: 'appid-run-1',
           requester: 'test-user',
@@ -204,9 +210,7 @@ describe('Application Validation Endpoints', () => {
     test('should return 404 for non-existent validation run id', async () => {
       const response = await httpClient.post(
         '/application/validation-run/999999999',
-        {
-          headers: { Authorization: getAuthHeader() }
-        }
+        { headers }
       )
 
       expect(response.status).toBe(404)
@@ -218,7 +222,7 @@ describe('Application Validation Endpoints', () => {
 
     test('should create validation run', async () => {
       const response = await httpClient.post('/api/v2/application/validate', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
           applicationId: testApplicationId,
           requester: 'test-user',
@@ -246,7 +250,7 @@ describe('Application Validation Endpoints', () => {
       const response = await httpClient.post(
         `/application/${testApplicationId}/validation-run`,
         {
-          headers: { Authorization: getAuthHeader() },
+          headers,
           body: {
             fields: []
           }
@@ -264,6 +268,7 @@ describe('Application Validation Endpoints', () => {
       const response = await httpClient.post(
         `/application/${testApplicationId}/validation-run`,
         {
+          headers: { 'X-Forwarded-Authorization': 'dummy' },
           body: {
             fields: []
           }

--- a/src/tests/e2e-tests/case-management-adapter.e2e.test.js
+++ b/src/tests/e2e-tests/case-management-adapter.e2e.test.js
@@ -2,12 +2,17 @@ import { describe, test, expect, beforeAll } from 'vitest'
 import { httpClient } from './setup/http-client.js'
 import { getAuthHeader } from './setup/auth-helpers.js'
 
+const headers = {
+  Authorization: getAuthHeader(),
+  'X-Forwarded-Authorization': 'dummy'
+}
+
 describe('Case Management Adapter Endpoints', () => {
   let validationRunId
 
   beforeAll(async () => {
     const response = await httpClient.post('/api/v2/application/validate', {
-      headers: { Authorization: getAuthHeader() },
+      headers,
       body: {
         applicationId: 'appid-cma-1',
         requester: 'test-user',
@@ -36,9 +41,7 @@ describe('Case Management Adapter Endpoints', () => {
     test('should retrieve validation run by id with authentication', async () => {
       const response = await httpClient.get(
         `/case-management-adapter/application/validation-run/${validationRunId}`,
-        {
-          headers: { Authorization: getAuthHeader() }
-        }
+        { headers }
       )
 
       expect(response.status).toBe(200)
@@ -56,7 +59,7 @@ describe('Case Management Adapter Endpoints', () => {
       const response = await httpClient.post(
         '/case-management-adapter/application/validation-run/rerun',
         {
-          headers: { Authorization: getAuthHeader() },
+          headers,
           body: {
             requesterUsername: 'test-user',
             id: validationRunId
@@ -77,7 +80,7 @@ describe('Case Management Adapter Endpoints', () => {
       const response = await httpClient.post(
         '/case-management-adapter/application/validation-run/rerun',
         {
-          headers: { Authorization: getAuthHeader() },
+          headers,
           body: {
             requesterUsername: 'test-user',
             id: 999999999

--- a/src/tests/e2e-tests/parcels.e2e.test.js
+++ b/src/tests/e2e-tests/parcels.e2e.test.js
@@ -2,12 +2,18 @@ import { describe, test, expect } from 'vitest'
 import { httpClient } from './setup/http-client.js'
 import { getAuthHeader } from './setup/auth-helpers.js'
 
+const headers = {
+  Authorization: getAuthHeader(),
+  'X-Forwarded-Authorization': 'dummy'
+}
+
 describe('Parcels Endpoints', () => {
   describe('POST /api/v2/parcels', () => {
     test('should return parcel data with size and actions when authenticated', async () => {
       const response = await httpClient.post('/api/v2/parcels', {
-        headers: { Authorization: getAuthHeader() },
+        headers,
         body: {
+          sbi: '0123456789',
           parcelIds: ['SD5649-9215'],
           fields: ['size', 'actions']
         }

--- a/src/tests/e2e-tests/setup/startup.js
+++ b/src/tests/e2e-tests/setup/startup.js
@@ -1,14 +1,17 @@
+import { config } from '~/src/config/index.js'
 import { ingestLandData } from '~/scripts/local-ingest-service.js'
 import {
   startTestServer,
   getBaseUrl
 } from '~/src/tests/e2e-tests/setup/server.js'
-import { setBaseUrl } from '~/src/tests/e2e-tests/setup/http-client.js'
 import { mockApiCalls } from '~/src/tests/e2e-tests/setup/mocks.js'
+import { setBaseUrl } from '~/src/tests/e2e-tests/setup/http-client.js'
 
 let isSeeded = false
 
 export default async () => {
+  // TODO: Enable once we have a usable DAL stub for e2e tests
+  config.set('featureFlags.useDal', false)
   mockApiCalls()
 
   if (!isSeeded) {


### PR DESCRIPTION
Pass defra ID token and SBI down to where we fetch agreements as these
are needed by the DAL; we're getting these in the endpoint call from
grants UI.

Update DAL retrieval to handle a 404 with an empty array since a
business may not be known to the DAL.

Note that this change makes the sbi parameter mandatory in the parcels
endpoint, meaning this can only be deployed after Grants UI starts
providing it.

Add a small fix to the plannedActionsTransformer, which is always
expecting hectares -- it should respect unit = sqm and not try to
convert it, though more to the point we should always have sqm by this
point; this will be fixed properly in a future ticket to ensure values
in our db are always stored as sqm.

Feature flag going out to DAL because there's still more work to be done
with ENTRA tokens and service-to-service auth to get it to work in a
non-dev environment. With the flag off the DAL client will just return
[] for agreements
