### PR TITLE
GSPS-507: Accept string|number for SBI in validate

### DIFF
--- a/src/features/application/controllers/2.0.0/application-validation.controller.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.js
@@ -287,8 +287,11 @@ const ApplicationValidationController = {
       // @ts-expect-error - postgresDb
       const postgresDb = request.server.postgresDb
       // @ts-expect-error - payload
-      const { landActions, applicationId, sbi, applicantCrn, requester } =
+      const { landActions, applicationId, applicantCrn, requester } =
         request.payload
+
+      // @ts-expect-error - payload
+      const sbi = String(request.payload.sbi)
 
       logInfo(request.logger, {
         category: 'application',
@@ -306,7 +309,7 @@ const ApplicationValidationController = {
         {
           landActions,
           applicationId,
-          sbi: String(sbi),
+          sbi,
           applicantCrn,
           requester
         }

--- a/src/features/application/controllers/2.0.0/application-validation.controller.test.js
+++ b/src/features/application/controllers/2.0.0/application-validation.controller.test.js
@@ -36,6 +36,8 @@ const mockValidateRequestData = vi.mocked(validateRequestData)
 const mockValidateAllLandParcels = vi.mocked(validateAllLandParcels)
 const mockAuditEvent = vi.mocked(auditEvent)
 
+const sbi = '123456789'
+
 describe('ApplicationValidationController', () => {
   const server = Hapi.server()
 
@@ -181,7 +183,6 @@ describe('ApplicationValidationController', () => {
   describe('POST /applications/validate route', () => {
     test('should return 200 with valid application when validation passes', async () => {
       const applicationId = 'APP-123'
-      const sbi = 123456789
       const request = {
         method: 'POST',
         headers: { 'x-forwarded-authorization': 'dummy-token' },
@@ -258,9 +259,34 @@ describe('ApplicationValidationController', () => {
       )
     })
 
+    test('should allow number for SBI', async () => {
+      const applicationId = 'APP-123'
+      const request = {
+        method: 'POST',
+        headers: { 'x-forwarded-authorization': 'dummy-token' },
+        url: '/api/v2/application/validate',
+        payload: {
+          applicationId,
+          requester: 'test-user',
+          applicantCrn: 'CRN-456',
+          sbi: 123456789,
+          landActions: mockLandActions
+        }
+      }
+
+      /** @type { Hapi.ServerInjectResponse<object> } */
+      const {
+        statusCode,
+        result: { valid, id }
+      } = await server.inject(request)
+
+      expect(statusCode).toBe(200)
+      expect(valid).toBe(true)
+      expect(id).toBe(1)
+    })
+
     test('should send an audit event with the eligibility decisions and explanations', async () => {
       const applicationId = 'APP-123'
-      const sbi = 123456789
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
@@ -313,7 +339,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -324,7 +350,7 @@ describe('ApplicationValidationController', () => {
         AuditEvent.SFI_APPLICATION_VALIDATED,
         expect.objectContaining({
           applicationId: 'APP-123',
-          identifiers: { sbi: 123456789, crn: 'CRN-456' },
+          identifiers: { sbi, crn: 'CRN-456' },
           request: { landActions: mockLandActions },
           error: 'Database connection failed'
         }),
@@ -335,7 +361,6 @@ describe('ApplicationValidationController', () => {
 
     test('should return 401 when missing X-Forwarded-Authorization header', async () => {
       const applicationId = 'APP-123'
-      const sbi = 123456789
       const request = {
         method: 'POST',
         url: '/api/v2/application/validate',
@@ -369,7 +394,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -397,7 +422,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -423,7 +448,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -462,7 +487,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -490,7 +515,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -514,7 +539,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: [
             {
               sheetId: 'SX0679',
@@ -549,7 +574,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: []
         }
       }
@@ -575,7 +600,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -602,7 +627,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }
@@ -631,7 +656,7 @@ describe('ApplicationValidationController', () => {
           applicationId: 'APP-123',
           requester: 'test-user',
           applicantCrn: 'CRN-456',
-          sbi: 123456789,
+          sbi,
           landActions: mockLandActions
         }
       }

--- a/src/features/application/schema/application-validation.schema.js
+++ b/src/features/application/schema/application-validation.schema.js
@@ -4,7 +4,7 @@ const applicationValidationSchema = Joi.object({
   applicationId: Joi.string().required(),
   requester: Joi.string().required(),
   applicantCrn: Joi.string().required(),
-  sbi: Joi.number().integer().required(),
+  sbi: Joi.alternatives(Joi.string(), Joi.number().integer()).required(),
   landActions: Joi.array()
     .items(
       Joi.object({

--- a/src/features/application/schema/application-validation.schema.test.js
+++ b/src/features/application/schema/application-validation.schema.test.js
@@ -52,12 +52,6 @@ describe('Application Validation Schema', () => {
       expect(error.details[0].message).toContain('applicantCrn')
     })
 
-    it('should require sbi as integer', () => {
-      const data = { ...validData, sbi: 'not-a-number' }
-      const { error } = applicationValidationSchema.validate(data)
-      expect(error.details[0].message).toContain('sbi')
-    })
-
     it('should require landActions array with minimum 1 item', () => {
       const data = { ...validData, landActions: [] }
       const { error } = applicationValidationSchema.validate(data)


### PR DESCRIPTION
Part one: accept string for SBI in /application/validate to allow grants
UI to start passing it as one.

We'll then stop allowing Number once they're passing it as a string in
all environments.
