### PR TITLE
GSPS-508 Sanitize the request IP address when auditing events

### DIFF
--- a/src/features/common/helpers/audit-event.js
+++ b/src/features/common/helpers/audit-event.js
@@ -1,30 +1,7 @@
-import { networkInterfaces } from 'node:os'
-
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns'
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/features/common/helpers/logging/logger.js'
-
-/**
- * Resolves the IP to record on the audit event: prefers the Hapi server's
- * bound host (when not the "listen on all interfaces" wildcard), then falls
- * back to this service's own non-internal IPv4 address.
- * @param {import('@hapi/hapi').Request|null} [request]
- * @returns {string}
- */
-const getLocalIp = (request) => {
-  const hapiHost = request?.server?.info?.host
-  if (hapiHost && hapiHost !== '0.0.0.0') {
-    return hapiHost
-  }
-  for (const iface of Object.values(networkInterfaces())) {
-    for (const addr of iface ?? []) {
-      if (!addr.internal && addr.family === 'IPv4') {
-        return addr.address
-      }
-    }
-  }
-  return ''
-}
+import { extractIp } from '~/src/features/common/helpers/request-ip.js'
 
 /**
  * Resolves the correlation id to record on audit events from the tracing header.
@@ -122,7 +99,7 @@ const buildAuditPayload = (
     version: '0.1.0',
     application: 'Grants',
     component: config.get('serviceName'),
-    ip: getLocalIp(request),
+    ip: extractIp(request),
 
     ...(hasSecurity && {
       security: {

--- a/src/features/common/helpers/audit-event.test.js
+++ b/src/features/common/helpers/audit-event.test.js
@@ -15,12 +15,12 @@ const mockConfigGet = vi.hoisted(() =>
   })
 )
 
-const mockNetworkInterfaces = vi.hoisted(() => vi.fn())
+const mockExtractIp = vi.hoisted(() => vi.fn())
 
 vi.mock('~/src/config/index.js', () => ({ config: { get: mockConfigGet } }))
 
-vi.mock('node:os', () => ({
-  networkInterfaces: mockNetworkInterfaces
+vi.mock('~/src/features/common/helpers/request-ip.js', () => ({
+  extractIp: mockExtractIp
 }))
 
 describe('AuditEvent', () => {
@@ -81,9 +81,7 @@ describe('auditEvent', () => {
     vi.resetModules()
     mockSend = vi.fn().mockResolvedValue({})
     mockLogger = { info: vi.fn(), warn: vi.fn() }
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {
         this.send = mockSend
@@ -193,48 +191,21 @@ describe('auditEvent', () => {
     })
   })
 
-  test('ip is populated from request.server.info.host when available', async () => {
-    const mockRequest = { server: { info: { host: '10.0.0.5' } } }
+  test('ip is populated from extractIp(request)', async () => {
+    mockExtractIp.mockReturnValue('10.0.0.5')
+    const mockRequest = { headers: { 'x-forwarded-for': '10.0.0.5' } }
 
     await auditEvent(UNMAPPED_EVENT, {}, 'success', mockRequest)
 
+    expect(mockExtractIp).toHaveBeenCalledWith(mockRequest)
     expect(getPublishedPayload().ip).toBe('10.0.0.5')
   })
 
-  test('ip falls back to os.networkInterfaces() when no request is available', async () => {
+  test('ip is populated from extractIp(null) when no request is available', async () => {
     await auditEvent(UNMAPPED_EVENT, {})
 
+    expect(mockExtractIp).toHaveBeenCalledWith(null)
     expect(getPublishedPayload().ip).toBe('192.168.1.100')
-  })
-
-  test('ip falls back to os.networkInterfaces() when server host is 0.0.0.0', async () => {
-    const mockRequest = { server: { info: { host: '0.0.0.0' } } }
-
-    await auditEvent(UNMAPPED_EVENT, {}, 'success', mockRequest)
-
-    expect(getPublishedPayload().ip).toBe('192.168.1.100')
-  })
-
-  test('ip is empty when no non-internal IPv4 interface is found', async () => {
-    mockNetworkInterfaces.mockReturnValue({
-      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
-      eth0: [{ address: 'fe80::1', family: 'IPv6', internal: false }]
-    })
-
-    await auditEvent(UNMAPPED_EVENT, {})
-
-    expect(getPublishedPayload().ip).toBe('')
-  })
-
-  test('skips interface entries that are undefined', async () => {
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: undefined,
-      eth1: [{ address: '10.0.0.9', family: 'IPv4', internal: false }]
-    })
-
-    await auditEvent(UNMAPPED_EVENT, {})
-
-    expect(getPublishedPayload().ip).toBe('10.0.0.9')
   })
 
   test('passes failure status through to the published payload', async () => {
@@ -283,9 +254,7 @@ describe('auditEvent - SFI_PAYMENT_CALCULATED', () => {
   beforeEach(async () => {
     vi.resetModules()
     mockSend = vi.fn().mockResolvedValue({})
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {
         this.send = mockSend
@@ -373,9 +342,7 @@ describe('auditEvent - SFI_APPLICATION_VALIDATED', () => {
   beforeEach(async () => {
     vi.resetModules()
     mockSend = vi.fn().mockResolvedValue({})
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {
         this.send = mockSend
@@ -455,9 +422,7 @@ describe('auditEvent - WMP_PAYMENT_CALCULATED', () => {
   beforeEach(async () => {
     vi.resetModules()
     mockSend = vi.fn().mockResolvedValue({})
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {
         this.send = mockSend
@@ -532,9 +497,7 @@ describe('auditEvent - WMP_VALIDATED', () => {
   beforeEach(async () => {
     vi.resetModules()
     mockSend = vi.fn().mockResolvedValue({})
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {
         this.send = mockSend
@@ -621,9 +584,7 @@ describe('auditEvent error handling', () => {
     vi.resetModules()
     mockSend = vi.fn()
     mockLogger = { info: vi.fn(), warn: vi.fn() }
-    mockNetworkInterfaces.mockReturnValue({
-      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
-    })
+    mockExtractIp.mockReturnValue('192.168.1.100')
 
     vi.doMock('@aws-sdk/client-sns', () => ({
       SNSClient: vi.fn().mockImplementation(function () {

--- a/src/features/common/helpers/request-ip.js
+++ b/src/features/common/helpers/request-ip.js
@@ -1,0 +1,91 @@
+import { networkInterfaces } from 'node:os'
+
+/**
+ * Sentinel audit schema constraint: `ip` must be present and at most 20
+ * characters long (covers IPv4 and standard IPv6, but not multi-IP strings).
+ */
+const MAX_IP_LENGTH = 20
+
+/**
+ * Finds the first non-internal IPv4 address across all network interfaces.
+ * @param {object} interfaces result of `networkInterfaces()`
+ * @returns {{address: string}|undefined}
+ */
+const findNonInternalIPv4 = (interfaces) =>
+  Object.values(interfaces)
+    .flat()
+    .find((addr) => addr?.family === 'IPv4' && !addr?.internal)
+
+/**
+ * Resolves and caches this service's own non-internal IPv4 address, used as
+ * the audit `ip` for events that originate from scheduled tasks / SQS message
+ * processors where there is no inbound HTTP request to attribute.
+ * Falls back to `127.0.0.1` if no external interface is found, so the audit
+ * payload always satisfies the mandatory `ip` field.
+ * @returns {string}
+ */
+let cachedServiceIp = null
+export const getServiceIp = () => {
+  if (cachedServiceIp) {
+    return cachedServiceIp
+  }
+  try {
+    const found = findNonInternalIPv4(networkInterfaces())
+    if (found) {
+      cachedServiceIp = found.address
+      return cachedServiceIp
+    }
+  } catch {
+    // ignore — fall through to loopback default
+  }
+  cachedServiceIp = '127.0.0.1'
+  return cachedServiceIp
+}
+
+/**
+ * Normalises a raw IP string to a single, schema-compliant address.
+ *  - keeps only the first entry of an `x-forwarded-for` style list
+ *  - strips a trailing `:port` from IPv4 (`1.2.3.4:5678` → `1.2.3.4`)
+ *  - strips an IPv6 zone id (`fe80::1%eth0` → `fe80::1`)
+ *  - returns `''` if the result is still longer than 20 chars (caller falls back)
+ * @param {string} raw
+ * @returns {string}
+ */
+export const sanitiseIp = (raw) => {
+  if (!raw || typeof raw !== 'string') {
+    return ''
+  }
+  let ip = raw.split(',')[0].trim()
+  // strip IPv6 zone id
+  ip = ip.split('%')[0]
+  // strip :port from IPv4 (an IPv6 address contains multiple colons, leave it alone)
+  if ((ip.match(/:/g) ?? []).length === 1) {
+    ip = ip.split(':')[0]
+  }
+  if (ip.length === 0 || ip.length > MAX_IP_LENGTH) {
+    return ''
+  }
+  return ip
+}
+
+/**
+ * Resolve the IP to record on the audit event.
+ *  - If an inbound Hapi request is provided, prefer the first
+ *    `x-forwarded-for` entry, then `request.info.remoteAddress`.
+ *  - If neither yields a usable single IP within the 20-char limit, or no
+ *    request is provided (e.g. SQS / scheduled task), fall back to this
+ *    service's own IP so the mandatory `ip` field is always populated.
+ * @param {object} [request]
+ * @returns {string}
+ */
+export const extractIp = (request) => {
+  const forwarded = sanitiseIp(request?.headers?.['x-forwarded-for'])
+  if (forwarded) {
+    return forwarded
+  }
+  const remote = sanitiseIp(request?.info?.remoteAddress)
+  if (remote) {
+    return remote
+  }
+  return getServiceIp()
+}

--- a/src/features/common/helpers/request-ip.test.js
+++ b/src/features/common/helpers/request-ip.test.js
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockNetworkInterfaces = vi.hoisted(() => vi.fn())
+
+vi.mock('node:os', () => ({
+  networkInterfaces: mockNetworkInterfaces
+}))
+
+describe('sanitiseIp', () => {
+  let sanitiseIp
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ sanitiseIp } = await import('./request-ip.js'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('returns an already-clean IPv4 address unchanged', () => {
+    expect(sanitiseIp('1.2.3.4')).toBe('1.2.3.4')
+  })
+
+  test('returns an already-clean IPv6 address unchanged', () => {
+    expect(sanitiseIp('2001:db8::1')).toBe('2001:db8::1')
+  })
+
+  test('keeps only the first entry of an x-forwarded-for list', () => {
+    expect(sanitiseIp('1.2.3.4, 5.6.7.8, 9.10.11.12')).toBe('1.2.3.4')
+  })
+
+  test('trims whitespace around the first entry', () => {
+    expect(sanitiseIp('  1.2.3.4  , 5.6.7.8')).toBe('1.2.3.4')
+  })
+
+  test('strips a trailing port from an IPv4 address', () => {
+    expect(sanitiseIp('1.2.3.4:5678')).toBe('1.2.3.4')
+  })
+
+  test('strips an IPv6 zone id', () => {
+    expect(sanitiseIp('fe80::1%eth0')).toBe('fe80::1')
+  })
+
+  test('does not strip a port-like suffix from an IPv6 address', () => {
+    expect(sanitiseIp('2001:db8::1')).toBe('2001:db8::1')
+  })
+
+  test('returns an empty string for a result longer than 20 characters', () => {
+    expect(sanitiseIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe('')
+  })
+
+  test('returns an empty string for null', () => {
+    expect(sanitiseIp(null)).toBe('')
+  })
+
+  test('returns an empty string for undefined', () => {
+    expect(sanitiseIp(undefined)).toBe('')
+  })
+
+  test('returns an empty string for an empty string', () => {
+    expect(sanitiseIp('')).toBe('')
+  })
+
+  test('returns an empty string for a non-string value', () => {
+    expect(sanitiseIp(12345)).toBe('')
+  })
+})
+
+describe('getServiceIp', () => {
+  let getServiceIp
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ getServiceIp } = await import('./request-ip.js'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('returns the first non-internal IPv4 address', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
+    })
+
+    expect(getServiceIp()).toBe('192.168.1.100')
+  })
+
+  test('skips interface entries that are undefined', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: undefined,
+      eth1: [{ address: '10.0.0.9', family: 'IPv4', internal: false }]
+    })
+
+    expect(getServiceIp()).toBe('10.0.0.9')
+  })
+
+  test('ignores non-internal IPv6 interfaces', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: 'fe80::1', family: 'IPv6', internal: false }]
+    })
+
+    expect(getServiceIp()).toBe('127.0.0.1')
+  })
+
+  test('falls back to 127.0.0.1 when no non-internal IPv4 interface is found', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true }]
+    })
+
+    expect(getServiceIp()).toBe('127.0.0.1')
+  })
+
+  test('falls back to 127.0.0.1 when networkInterfaces() throws', () => {
+    mockNetworkInterfaces.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    expect(getServiceIp()).toBe('127.0.0.1')
+  })
+
+  test('caches the resolved address across calls', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
+    })
+
+    expect(getServiceIp()).toBe('192.168.1.100')
+
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: '10.0.0.1', family: 'IPv4', internal: false }]
+    })
+
+    expect(getServiceIp()).toBe('192.168.1.100')
+    expect(mockNetworkInterfaces).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('extractIp', () => {
+  let extractIp
+
+  beforeEach(async () => {
+    vi.resetModules()
+    mockNetworkInterfaces.mockReturnValue({
+      eth0: [{ address: '192.168.1.100', family: 'IPv4', internal: false }]
+    })
+    ;({ extractIp } = await import('./request-ip.js'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('prefers the first x-forwarded-for entry', () => {
+    const request = {
+      headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+      info: { remoteAddress: '9.9.9.9' }
+    }
+
+    expect(extractIp(request)).toBe('1.2.3.4')
+  })
+
+  test('falls back to request.info.remoteAddress when x-forwarded-for is absent', () => {
+    const request = { headers: {}, info: { remoteAddress: '9.9.9.9' } }
+
+    expect(extractIp(request)).toBe('9.9.9.9')
+  })
+
+  test('falls back to request.info.remoteAddress when x-forwarded-for sanitises to empty', () => {
+    const request = {
+      headers: { 'x-forwarded-for': '' },
+      info: { remoteAddress: '9.9.9.9' }
+    }
+
+    expect(extractIp(request)).toBe('9.9.9.9')
+  })
+
+  test('falls back to the service IP when no request is provided', () => {
+    expect(extractIp()).toBe('192.168.1.100')
+  })
+
+  test('falls back to the service IP when the request has no usable IP', () => {
+    const request = { headers: {}, info: {} }
+
+    expect(extractIp(request)).toBe('192.168.1.100')
+  })
+
+  test('falls back to the service IP when request.headers is absent', () => {
+    expect(extractIp({})).toBe('192.168.1.100')
+  })
+})


### PR DESCRIPTION
lift and shift of @charliejade8888 work for the agreements services, which is working fine in production

https://github.com/DEFRA/farming-grants-agreements-api/commit/b8fbb4776e113e5c79363400930eb7b2a38fe700