### PR TITLE
GSPS-513: Filter expired actions in getAgreements

### DIFF
--- a/src/features/agreements/queries/getAgreementsForParcel.query.js
+++ b/src/features/agreements/queries/getAgreementsForParcel.query.js
@@ -1,26 +1,13 @@
-import { isAfter, isBefore, isSameDay } from 'date-fns'
+import { agreementActionsTransformer } from '../transformers/agreements.transformer.js'
 import {
   logDatabaseError,
   logInfo
 } from '~/src/features/common/helpers/logging/log-helpers.js'
-import { agreementActionsTransformer } from '../transformers/agreements.transformer.js'
 
 /**
  * @import {AgreementAction} from '~/src/features/agreements/agreements.d.js'
  * @import {Logger} from '~/src/features/common/logger.d.js'
  */
-
-/**
- * Filter expired actions
- * @param {AgreementAction} action - The action to filter
- * @returns {boolean} True if the action is not expired, false otherwise
- */
-function filterExpiredActions({ startDate, endDate }) {
-  return (
-    (isBefore(startDate, new Date()) || isSameDay(startDate, new Date())) &&
-    isAfter(endDate, new Date())
-  )
-}
 
 /**
  * Get agreements for a parcel
@@ -43,7 +30,7 @@ async function getAgreementsForParcel(sheetId, parcelId, db, logger) {
       category: 'database',
       message: 'Get agreements for parcel'
     })
-    return agreementActionsTransformer(result.rows).filter(filterExpiredActions)
+    return agreementActionsTransformer(result.rows)
   } catch (error) {
     logDatabaseError(logger, {
       operation: 'Get agreements for parcel',

--- a/src/features/agreements/queries/getAgreementsForParcel.query.test.js
+++ b/src/features/agreements/queries/getAgreementsForParcel.query.test.js
@@ -20,11 +20,6 @@ describe('getAgreementsForParcel', () => {
       info: vi.fn(),
       error: vi.fn()
     }
-    vi.useFakeTimers().setSystemTime(new Date('2025-12-01T00:00:00.000Z'))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   test('should connect to the database', async () => {
@@ -88,126 +83,6 @@ describe('getAgreementsForParcel', () => {
         quantity: 0.5,
         startDate: new Date('2025-01-01'),
         endDate: new Date('2025-12-31')
-      },
-      {
-        actionCode: 'CMOR1',
-        unit: 'ha',
-        quantity: 1.2,
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-12-31')
-      }
-    ])
-  })
-
-  test.each([
-    {
-      scenario: 'expired actions',
-      filteredAction: {
-        actionCode: 'UPL1',
-        unit: 'ha',
-        quantity: 0.5,
-        startDate: '2025-01-01',
-        endDate: '2025-11-30'
-      }
-    },
-    {
-      scenario: 'actions not yet started',
-      filteredAction: {
-        actionCode: 'UPL1',
-        unit: 'ha',
-        quantity: 0.5,
-        startDate: '2026-01-01',
-        endDate: '2026-12-31'
-      }
-    },
-    {
-      scenario: 'actions where end date is today',
-      filteredAction: {
-        actionCode: 'UPL1',
-        unit: 'ha',
-        quantity: 0.5,
-        startDate: '2025-01-01',
-        endDate: '2025-12-01'
-      }
-    }
-  ])('should exclude $scenario', async ({ filteredAction }) => {
-    const sheetId = 'SH123'
-    const parcelId = 'PA456'
-    mockClient.query = vi.fn().mockResolvedValue({
-      rows: [
-        {
-          actions: [
-            filteredAction,
-            {
-              actionCode: 'CMOR1',
-              unit: 'ha',
-              quantity: 1.2,
-              startDate: '2025-01-01',
-              endDate: '2025-12-31'
-            }
-          ]
-        }
-      ]
-    })
-
-    const result = await getAgreementsForParcel(
-      sheetId,
-      parcelId,
-      mockDb,
-      mockLogger
-    )
-
-    expect(result).toEqual([
-      {
-        actionCode: 'CMOR1',
-        unit: 'ha',
-        quantity: 1.2,
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-12-31')
-      }
-    ])
-  })
-
-  test('should include action when starting today', async () => {
-    const sheetId = 'SH123'
-    const parcelId = 'PA456'
-    mockClient.query = vi.fn().mockResolvedValue({
-      rows: [
-        {
-          actions: [
-            {
-              actionCode: 'UPL1',
-              unit: 'ha',
-              quantity: 0.5,
-              startDate: '2025-12-01',
-              endDate: '2026-12-31'
-            },
-            {
-              actionCode: 'CMOR1',
-              unit: 'ha',
-              quantity: 1.2,
-              startDate: '2025-01-01',
-              endDate: '2025-12-31'
-            }
-          ]
-        }
-      ]
-    })
-
-    const result = await getAgreementsForParcel(
-      sheetId,
-      parcelId,
-      mockDb,
-      mockLogger
-    )
-
-    expect(result).toEqual([
-      {
-        actionCode: 'UPL1',
-        unit: 'ha',
-        quantity: 0.5,
-        startDate: new Date('2025-12-01'),
-        endDate: new Date('2026-12-31')
       },
       {
         actionCode: 'CMOR1',

--- a/src/features/agreements/repo.js
+++ b/src/features/agreements/repo.js
@@ -1,3 +1,4 @@
+import { expiredActionsFilter } from '~/src/features/agreements/transformers/filters.js'
 import { getAgreementsForParcel as getFromDb } from '~/src/features/agreements/queries/getAgreementsForParcel.query.js'
 import { getAgreements as getFromDal } from '~/src/services/dal/index.js'
 
@@ -5,7 +6,8 @@ import { getAgreements as getFromDal } from '~/src/services/dal/index.js'
  * Retrieve agreements for a parcel, from multiple sources
  *
  * N.B. currently agreements are only fetched in order to calculate available
- * area, so we filter the results to those which are area-based (sqm).
+ * area, so we filter the results to those which are area-based (sqm). We also
+ * filter out expired agreements.
  * @param {string} sbi - The SBI for the business owning the parcel
  * @param {string} sheetId - The sheetId
  * @param {string} parcelId - The parcelId
@@ -27,7 +29,10 @@ export async function getAgreements(
     getFromDal(sbi, parcelId, sheetId, defraIdToken, logger)
   ])
 
-  return results.flat().filter((a) => a.unit === 'sqm')
+  return results
+    .flat()
+    .filter((a) => a.unit === 'sqm')
+    .filter(expiredActionsFilter)
 }
 
 /**

--- a/src/features/agreements/repo.test.js
+++ b/src/features/agreements/repo.test.js
@@ -5,33 +5,41 @@ import { getAgreements } from '~/src/features/agreements/repo.js'
 vi.mock('~/src/features/agreements/queries/getAgreementsForParcel.query.js')
 vi.mock('~/src/services/dal/index.js')
 
+const sbi = '012345678'
+const sheetId = 'dummy-sheet'
+const parcelId = 'dummy-parcel'
+const token = 'dummy-defra-id-token'
 const mockLogger = { info: vi.fn() }
+
+// Default dates which are valid for today (with fake timer)
+const startDate = new Date('2025-01-01')
+const endDate = new Date('2027-01-01')
 
 describe('getAgreements', () => {
   beforeEach(() => {
+    vi.useFakeTimers().setSystemTime(new Date('2025-12-01T00:00:00.000Z'))
     vi.clearAllMocks()
   })
 
-  it('should fetch agreements from both the DB and the DAL', async () => {
-    const sbi = '012345678'
-    const sheetId = 'dummy-sheet'
-    const parcelId = 'dummy-parcel'
-    const token = 'dummy-defra-id-token'
+  afterEach(() => {
+    vi.useRealTimers()
+  })
 
+  it('should fetch agreements from both the DB and the DAL', async () => {
     const dbAgreements = [
       {
         actionCode: 'UPL1',
         quantity: 100,
         unit: 'sqm',
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-11-31')
+        startDate,
+        endDate
       },
       {
         actionCode: 'UPL2',
         quantity: 10000,
         unit: 'sqm',
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-11-31')
+        startDate,
+        endDate
       }
     ]
     const dalAgreements = [
@@ -39,15 +47,15 @@ describe('getAgreements', () => {
         actionCode: 'CMOR1',
         quantity: 15000,
         unit: 'sqm',
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-11-31')
+        startDate,
+        endDate
       },
       {
         actionCode: 'CMOR2',
         quantity: 17000,
         unit: 'sqm',
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-11-31')
+        startDate,
+        endDate
       }
     ]
 
@@ -81,40 +89,35 @@ describe('getAgreements', () => {
   })
 
   it('should filter out non-area agreements', async () => {
-    const sbi = '012345678'
-    const sheetId = 'dummy-sheet'
-    const parcelId = 'dummy-parcel'
-    const token = 'dummy-defra-id-token'
-
     const dbAgreementCount = {
       actionCode: 'AF1',
       quantity: 800,
       unit: 'count',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2025-11-31')
+      startDate,
+      endDate
     }
 
     const dbAgreementArea = {
       actionCode: 'UPL1',
       quantity: 100,
       unit: 'sqm',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2025-11-31')
+      startDate,
+      endDate
     }
 
     const dalAgreementLength = {
       actionCode: 'SPM4',
       quantity: 200,
       unit: 'm',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2025-11-31')
+      startDate,
+      endDate
     }
     const dalAgreementArea = {
       actionCode: 'CMOR1',
       quantity: 15000,
       unit: 'sqm',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2025-11-31')
+      startDate,
+      endDate
     }
 
     db.getAgreementsForParcel.mockResolvedValue([
@@ -147,5 +150,87 @@ describe('getAgreements', () => {
     )
 
     expect(result).toEqual([dbAgreementArea, dalAgreementArea])
+  })
+
+  test.each([
+    {
+      scenario: 'expired actions',
+      filteredAction: {
+        actionCode: 'UPL1',
+        quantity: 100,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-11-30')
+      }
+    },
+    {
+      scenario: 'actions not yet started',
+      filteredAction: {
+        actionCode: 'UPL1',
+        quantity: 100,
+        unit: 'sqm',
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31')
+      }
+    },
+    {
+      scenario: 'actions where end date is today',
+      filteredAction: {
+        actionCode: 'UPL1',
+        quantity: 100,
+        unit: 'sqm',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-01')
+      }
+    }
+  ])('should exclude $scenario', async ({ filteredAction }) => {
+    const sheetId = 'SH123'
+    const parcelId = 'PA456'
+
+    const goodAction = {
+      actionCode: 'UPL1',
+      quantity: 100,
+      unit: 'sqm',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2030-11-31')
+    }
+
+    db.getAgreementsForParcel.mockResolvedValue([goodAction, filteredAction])
+    dal.getAgreements.mockResolvedValue([filteredAction])
+
+    const result = await getAgreements(
+      sbi,
+      sheetId,
+      parcelId,
+      token,
+      null,
+      mockLogger
+    )
+
+    expect(result).toEqual([goodAction])
+  })
+
+  test('should include actions starting today', async () => {
+    const goodAction = {
+      actionCode: 'UPL1',
+      quantity: 100,
+      unit: 'sqm',
+      startDate: new Date('2025-12-01'),
+      endDate
+    }
+
+    db.getAgreementsForParcel.mockResolvedValue([goodAction])
+    dal.getAgreements.mockResolvedValue([goodAction])
+
+    const result = await getAgreements(
+      sbi,
+      sheetId,
+      parcelId,
+      token,
+      null,
+      mockLogger
+    )
+
+    expect(result).toEqual([goodAction, goodAction])
   })
 })

--- a/src/features/agreements/transformers/filters.js
+++ b/src/features/agreements/transformers/filters.js
@@ -1,0 +1,17 @@
+import { isAfter, isBefore, isSameDay } from 'date-fns'
+
+/**
+ * Filter expired actions
+ * @param {AgreementAction} action - The action to filter
+ * @returns {boolean} True if the action is not expired, false otherwise
+ */
+export function expiredActionsFilter({ startDate, endDate }) {
+  return (
+    (isBefore(startDate, new Date()) || isSameDay(startDate, new Date())) &&
+    isAfter(endDate, new Date())
+  )
+}
+
+/**
+ * @import {AgreementAction} from '~/src/features/agreements/agreements.d.js'
+ */

--- a/src/features/agreements/transformers/filters.test.js
+++ b/src/features/agreements/transformers/filters.test.js
@@ -1,0 +1,42 @@
+import { expiredActionsFilter } from '~/src/features/agreements/transformers/filters.js'
+
+const basicAgreement = {
+  actionCode: 'UPL1',
+  quantity: 100,
+  unit: 'sqm'
+}
+
+describe('getAgreements', () => {
+  beforeEach(() => {
+    vi.useFakeTimers().setSystemTime(new Date('2025-12-01T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should filter out agreements which have expired or are in the future', () => {
+    const early = [
+      { startDate: new Date('2020-01-01'), endDate: new Date('2024-12-01') }, // expired last year
+      { startDate: new Date('2020-01-01'), endDate: new Date('2025-11-30') }, // expired yesterday
+      { startDate: new Date('2020-01-01'), endDate: new Date('2025-12-01') } // expired today
+    ]
+    const late = [
+      { startDate: new Date('2025-12-02'), endDate: new Date('2045-01-01') }, // starts tomorrow
+      { startDate: new Date('2026-01-01'), endDate: new Date('2045-01-01') } // starts next year
+    ]
+    const current = [
+      { startDate: new Date('2025-12-01'), endDate: new Date('2025-12-02') }, // starts today
+      { startDate: new Date('2020-01-01'), endDate: new Date('2045-01-01') } // many years
+    ]
+    const agreements = [...early, ...current, ...late].map((a) => ({
+      ...a,
+      ...basicAgreement
+    }))
+
+    const expected = current.map((a) => ({ ...a, ...basicAgreement }))
+    const actual = agreements.filter(expiredActionsFilter)
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
This filter was previously being done when calling postgres, before the
results came back (a little odd that it wasn't part of the query, but
*was* part of the function running the query)

Move the filter out into a shared module, and apply it when hitting
getAgreements to get agreements from all sources, instead of embedding
it within the db layer

Add unit tests for the filter
