### PR TITLE
GSPS-524 Include sibling actions as existing area demand in application validation

### DIFF
--- a/src/features/application/service/action-validation.service.js
+++ b/src/features/application/service/action-validation.service.js
@@ -8,6 +8,7 @@ import { formatExplanationSections } from '~/src/features/available-area/explana
 import { rules } from '~/src/features/rules-engine/rules/index.js';
 import { executeRules } from '~/src/features/rules-engine/rulesEngine.js';
 import { plannedActionsTransformer } from '../../parcel/transformers/parcelActions.transformer.js';
+import { haToSqm } from '~/src/features/common/helpers/measurement.js';
 import {
   actionResultTransformer,
   ruleEngineApplicationTransformer
@@ -40,18 +41,30 @@ export const validateLandAction = async (
     throw new Error('Unable to validate land action');
   }
 
+  // Other actions requested for this same parcel in this submission also
+  // compete for the parcel's area, alongside persisted agreements - both
+  // are treated as "existing" demand when computing this action's available area.
+  const siblingActions = landAction.actions
+    .filter((a) => a !== action)
+    .map((a) => ({ actionCode: a.code, areaSqm: haToSqm(a.quantity) }));
+
+  const existingActions = [
+    ...plannedActionsTransformer(agreements),
+    ...siblingActions
+  ];
+
   const aacDataRequirements = await getAvailableAreaDataRequirements(
     action.code,
     landAction.sheetId,
     landAction.parcelId,
-    plannedActionsTransformer(agreements),
+    existingActions,
     request.server.postgresDb,
     request.logger
   );
 
   const lpResult = findMaximumAvailableArea(
     action.code,
-    plannedActionsTransformer(agreements),
+    existingActions,
     compatibilityCheckFn,
     aacDataRequirements
   );

--- a/src/features/application/service/action-validation.service.test.js
+++ b/src/features/application/service/action-validation.service.test.js
@@ -115,7 +115,8 @@ describe('Action Validation Service', () => {
 
   const mockLandAction = {
     sheetId: 'SX0679',
-    parcelId: '9238'
+    parcelId: '9238',
+    actions: [mockAction]
   };
 
   const mockAgreements = [
@@ -269,6 +270,46 @@ describe('Action Validation Service', () => {
         mockActionConfig,
         mockAvailableAreaResult,
         mockRuleResult
+      );
+    });
+
+    test('should include other actions requested for the same parcel as existing area demand', async () => {
+      const siblingAction = { code: 'UPL1', quantity: 5 };
+      const landActionWithSiblings = {
+        ...mockLandAction,
+        actions: [mockAction, siblingAction]
+      };
+      mockPlannedActionsTransformer.mockReturnValue([
+        { actionCode: 'LIG2', areaSqm: 1000000 }
+      ]);
+
+      await validateLandAction(
+        mockAction,
+        mockActionConfig,
+        mockAgreements,
+        mockCompatibilityCheckFn,
+        landActionWithSiblings,
+        mockRequest
+      );
+
+      const expectedExistingActions = [
+        { actionCode: 'LIG2', areaSqm: 1000000 },
+        { actionCode: 'UPL1', areaSqm: 50000 }
+      ];
+
+      expect(mockGetAvailableAreaDataRequirements).toHaveBeenCalledWith(
+        mockAction.code,
+        landActionWithSiblings.sheetId,
+        landActionWithSiblings.parcelId,
+        expectedExistingActions,
+        mockPostgresDb,
+        mockLogger
+      );
+      expect(mockFindMaximumAvailableArea).toHaveBeenCalledWith(
+        mockAction.code,
+        expectedExistingActions,
+        mockCompatibilityCheckFn,
+        mockAvailableAreaDataRequirements
       );
     });
 


### PR DESCRIPTION
We were validating applications incorrectly.                                                                                                                                                                                                                                                      
For example CSIG3 action needs to use all of the available area for a parcel, whilst CSAM3 can use partial.                                                                                                                                                                                                                                                                               

  **Examples:**                                                                                                                                                                                            
1. Let's say a land parcel has 0.3271 of available area and I submit for validation the following actions:                                                                                                                                                                                                                                                                                
  ```[ { "code": "CLIG3", "quantity":0.3271}, {"code": "CSAM3", "quantity":0.3271}]```, then this should fail, because both are using the totality of the available area and that is impossible.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                            
  2.  Let's say a land parcel has 0.3271 of available area and I submit for validation the following actions:                                                                                                                                                                                                                                                                               
    ```[ { "code": "CLIG3", "quantity":0.2271}, {"code": "CSAM3", "quantity":0.1}]```, then this should pass, because both are using the totality of the available area: CSAM3 is using partially and CLIG3 is using the remaining total available area.

examples, kindly provided by Narahari                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                           
 