### PR TITLE
GSPS-504: DAL: use robot service account

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -303,6 +303,12 @@ const config = convict({
       format: String,
       default: '',
       env: 'DAL_API_ENDPOINT'
+    },
+    serviceAccount: {
+      doc: 'Robot account email address to use for service to service auth',
+      format: String,
+      default: 'land-grants-api@defra.gov.uk',
+      env: 'DAL_SERVICE_ACCOUNT'
     }
   },
   featureFlags: {

--- a/src/services/dal/index.js
+++ b/src/services/dal/index.js
@@ -19,24 +19,31 @@ export async function getAgreements(
   defraIdToken,
   logger
 ) {
-  // TODO(GSPS-504): In this case we should authenticate differently with the DAL and use service
-  // to service auth; this is not yet available so we'll return no results until implemented
-  if (defraIdToken === null) {
-    return Promise.resolve([]);
-  }
-
   if (!config.get('featureFlags.useDal')) {
     return Promise.resolve([]);
   }
 
   const endpoint = config.get('dal.apiEndpoint');
 
+  // Use X-Forwarded-Authorization to pass along the end user's defra ID token if available.
+  // For requests without an end user present, we use our "robot" service account auth instead
+  /** @type {object} */
+  const authHeaders =
+    defraIdToken !== null
+      ? {
+          'Gateway-Type': 'external',
+          'X-Forwarded-Authorization': defraIdToken
+        }
+      : {
+          'Gateway-Type': 'internal',
+          Email: config.get('dal.serviceAccount')
+        };
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Gateway-Type': 'external',
-      'X-Forwarded-Authorization': defraIdToken
+      ...authHeaders
     },
     body: JSON.stringify({ query: GET_BUSINESS, variables: { sbi } })
   });

--- a/src/services/dal/index.test.js
+++ b/src/services/dal/index.test.js
@@ -27,13 +27,18 @@ describe('getAgreements', () => {
   const sbi = '123456789';
 
   afterEach(() => {
-    config.set('dal.apiEndpoint', config.default('dal.apiEndpoint'));
-    config.set('featureFlags.useDal', config.default('featureFlags.useDal'));
+    ['dal.apiEndpoint', 'dal.serviceAccount', 'featureFlags.useDal'].forEach(
+      (v) => {
+        config.set(v, config.default(v));
+      }
+    );
   });
 
   beforeEach(() => {
     config.set('dal.apiEndpoint', stubEndpoint);
+    config.set('dal.serviceAccount', 'land-grants-api@defra.gov.uk');
     config.set('featureFlags.useDal', true);
+
     vi.clearAllMocks();
     global.fetch = vi.fn();
   });
@@ -113,8 +118,12 @@ describe('getAgreements', () => {
     expect(result).toEqual([]);
   });
 
-  // TODO: replace with service-to-service auth in this scenario
-  it('returns an empty array when missing a defra ID token', async () => {
+  it('uses the robot service account for auth when missing a defra ID token', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(dalResponse)
+    });
+
     const result = await getAgreements(
       sbi,
       PARCEL_ID,
@@ -123,7 +132,20 @@ describe('getAgreements', () => {
       mockLogger
     );
 
-    expect(fetch).not.toBeCalled();
-    expect(result).toEqual([]);
+    expect(fetch).toHaveBeenCalledWith(
+      stubEndpoint,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Gateway-Type': 'internal',
+          Email: 'land-grants-api@defra.gov.uk'
+        }),
+        body: JSON.stringify({ query: GET_BUSINESS, variables: { sbi } })
+      })
+    );
+    expect(result).toEqual(
+      dalBusinessToAgreements(dalResponse.data.business, PARCEL_ID, SHEET_ID)
+    );
   });
 });


### PR DESCRIPTION
Add config for a robot service account (internal user email) and use it
to authenticate with the DAL when we're not using an external user's
DEFRA ID for auth.
