### PR TITLE
GSPS-465: add generic manual-check-required rule for WBD1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 lint:
-	npm run lint
-	npm run lint:types
-	npm run format:check
+	npm run lint && npm run format:check
 
 lint-fix:
 	npm run lint:fix

--- a/src/features/actions/action.d.js
+++ b/src/features/actions/action.d.js
@@ -41,7 +41,11 @@
 
 /**
  * @typedef {object} ActionRule
- * @property {number} name
+ * @property {string} name
+ * @property {string} [type] - Optional override selecting which registered rule executor
+ * to dispatch to (rules-engine/rules/index.js key is `${type ?? name}-${version}`). Lets a
+ * generic, reusable executor (e.g. 'manual-check-required') be configured under any
+ * per-action `name` (e.g. 'pond-check-required') without a new registry entry.
  * @property {string} description
  * @property {ActionRuleConfig} config
  * @property {string} version
@@ -52,6 +56,7 @@
  * @property {string} layerName
  * @property {number} minimumIntersectionPercent
  * @property {number} tolerancePercent
+ * @property {string} caveatDescription
  */
 
 /**

--- a/src/features/application/schema/2.0.0/application-validation.schema.js
+++ b/src/features/application/schema/2.0.0/application-validation.schema.js
@@ -1,12 +1,5 @@
 import Joi from 'joi'
 
-// Only these caveat codes come from GIS overlap rules (sssi-consent-required,
-// hefer-consent-required) run against hectare/m2-measured actions - they always
-// compute an overlap percentage/area. Caveats from other rules (e.g.
-// manual-check-required, used by unit/item actions like WBD1's pond check)
-// have no overlap to report.
-const overlapCaveatCodes = ['sssi-consent-required', 'hefer-consent-required']
-
 const applicationValidationResponseSchemaV2 = Joi.object({
   message: Joi.string().required(),
   id: Joi.number().integer().required(),
@@ -37,14 +30,8 @@ const applicationValidationResponseSchemaV2 = Joi.object({
               actionCode: Joi.string().required(),
               parcelId: Joi.string().required(),
               sheetId: Joi.string().required(),
-              percentageOverlap: Joi.number(),
-              overlapAreaHectares: Joi.number()
-            }).when('code', {
-              is: Joi.valid(...overlapCaveatCodes),
-              then: Joi.object({
-                percentageOverlap: Joi.number().required(),
-                overlapAreaHectares: Joi.number().required()
-              })
+              percentageOverlap: Joi.number().optional(),
+              overlapAreaHectares: Joi.number().optional()
             })
           })
         })

--- a/src/features/application/schema/2.0.0/application-validation.schema.js
+++ b/src/features/application/schema/2.0.0/application-validation.schema.js
@@ -1,5 +1,12 @@
 import Joi from 'joi'
 
+// Only these caveat codes come from GIS overlap rules (sssi-consent-required,
+// hefer-consent-required) run against hectare/m2-measured actions - they always
+// compute an overlap percentage/area. Caveats from other rules (e.g.
+// manual-check-required, used by unit/item actions like WBD1's pond check)
+// have no overlap to report.
+const overlapCaveatCodes = ['sssi-consent-required', 'hefer-consent-required']
+
 const applicationValidationResponseSchemaV2 = Joi.object({
   message: Joi.string().required(),
   id: Joi.number().integer().required(),
@@ -30,8 +37,14 @@ const applicationValidationResponseSchemaV2 = Joi.object({
               actionCode: Joi.string().required(),
               parcelId: Joi.string().required(),
               sheetId: Joi.string().required(),
-              percentageOverlap: Joi.number().required(),
-              overlapAreaHectares: Joi.number().required()
+              percentageOverlap: Joi.number(),
+              overlapAreaHectares: Joi.number()
+            }).when('code', {
+              is: Joi.valid(...overlapCaveatCodes),
+              then: Joi.object({
+                percentageOverlap: Joi.number().required(),
+                overlapAreaHectares: Joi.number().required()
+              })
             })
           })
         })

--- a/src/features/application/schema/2.0.0/application-validation.schema.test.js
+++ b/src/features/application/schema/2.0.0/application-validation.schema.test.js
@@ -1,0 +1,99 @@
+import { applicationValidationResponseSchemaV2 } from './application-validation.schema.js'
+
+// Regression coverage for the caveat.metadata conditional: hefer-consent-required is a
+// GIS overlap rule (used by WBD1, a hectare/m2-measured action) and must always report
+// percentageOverlap/overlapAreaHectares; pond-check-required is WBD1's manual-check-required
+// caveat (a unit/item check) and has no overlap to report. A previous version of this
+// schema required both fields unconditionally, which made the API 500 on any
+// manual-check-required response - see wbd1-1.0.0.spec.js in grants-config-land-grants.
+describe('applicationValidationResponseSchemaV2', () => {
+  const buildResponse = (caveat) => ({
+    message: 'Application validated successfully',
+    id: 1,
+    valid: true,
+    actions: [
+      {
+        actionCode: 'WBD1',
+        sheetId: 'SD5649',
+        parcelId: '9215',
+        hasPassed: true,
+        version: '1.0.0',
+        rules: [
+          {
+            name: caveat.code,
+            passed: true,
+            caveat
+          }
+        ]
+      }
+    ]
+  })
+
+  describe('hefer-consent-required (GIS overlap rule)', () => {
+    it('accepts a caveat with percentageOverlap and overlapAreaHectares', () => {
+      const { error } = applicationValidationResponseSchemaV2.validate(
+        buildResponse({
+          code: 'hefer-consent-required',
+          description: 'A hefer is needed from Historic England',
+          metadata: {
+            actionCode: 'WBD1',
+            parcelId: '9215',
+            sheetId: 'SD5649',
+            percentageOverlap: 5,
+            overlapAreaHectares: 0.05
+          }
+        })
+      )
+      expect(error).toBeUndefined()
+    })
+
+    it('rejects a caveat missing percentageOverlap', () => {
+      const { error } = applicationValidationResponseSchemaV2.validate(
+        buildResponse({
+          code: 'hefer-consent-required',
+          description: 'A hefer is needed from Historic England',
+          metadata: {
+            actionCode: 'WBD1',
+            parcelId: '9215',
+            sheetId: 'SD5649',
+            overlapAreaHectares: 0.05
+          }
+        })
+      )
+      expect(error.message).toContain('percentageOverlap')
+    })
+
+    it('rejects a caveat missing overlapAreaHectares', () => {
+      const { error } = applicationValidationResponseSchemaV2.validate(
+        buildResponse({
+          code: 'hefer-consent-required',
+          description: 'A hefer is needed from Historic England',
+          metadata: {
+            actionCode: 'WBD1',
+            parcelId: '9215',
+            sheetId: 'SD5649',
+            percentageOverlap: 5
+          }
+        })
+      )
+      expect(error.message).toContain('overlapAreaHectares')
+    })
+  })
+
+  describe('pond-check-required (manual-check-required rule)', () => {
+    it('accepts a caveat with no overlap metadata', () => {
+      const { error } = applicationValidationResponseSchemaV2.validate(
+        buildResponse({
+          code: 'pond-check-required',
+          description: 'A manual pond check is required',
+          metadata: {
+            actionCode: 'WBD1',
+            parcelId: '9215',
+            sheetId: 'SD5649'
+          }
+        })
+      )
+      expect(error).toBeUndefined()
+    })
+  })
+})

--- a/src/features/application/schema/2.0.0/application-validation.schema.test.js
+++ b/src/features/application/schema/2.0.0/application-validation.schema.test.js
@@ -47,7 +47,7 @@ describe('applicationValidationResponseSchemaV2', () => {
       expect(error).toBeUndefined()
     })
 
-    it('rejects a caveat missing percentageOverlap', () => {
+    it('accepts a caveat missing percentageOverlap', () => {
       const { error } = applicationValidationResponseSchemaV2.validate(
         buildResponse({
           code: 'hefer-consent-required',
@@ -60,10 +60,10 @@ describe('applicationValidationResponseSchemaV2', () => {
           }
         })
       )
-      expect(error.message).toContain('percentageOverlap')
+      expect(error).toBeUndefined()
     })
 
-    it('rejects a caveat missing overlapAreaHectares', () => {
+    it('accepts a caveat missing overlapAreaHectares', () => {
       const { error } = applicationValidationResponseSchemaV2.validate(
         buildResponse({
           code: 'hefer-consent-required',
@@ -76,7 +76,7 @@ describe('applicationValidationResponseSchemaV2', () => {
           }
         })
       )
-      expect(error.message).toContain('overlapAreaHectares')
+      expect(error).toBeUndefined()
     })
   })
 

--- a/src/features/application/service/action-validation.service.js
+++ b/src/features/application/service/action-validation.service.js
@@ -9,6 +9,7 @@ import { rules } from '~/src/features/rules-engine/rules/index.js'
 import { executeRules } from '~/src/features/rules-engine/rulesEngine.js'
 import { plannedActionsTransformer } from '../../parcel/transformers/parcelActions.transformer.js'
 import { haToSqm } from '~/src/features/common/helpers/measurement.js'
+import { HECTARES } from '~/src/features/common/constants/unit_type.js'
 import {
   actionResultTransformer,
   ruleEngineApplicationTransformer
@@ -44,8 +45,16 @@ export const validateLandAction = async (
   // Other actions requested for this same parcel in this submission also
   // compete for the parcel's area, alongside persisted agreements - both
   // are treated as "existing" demand when computing this action's available area.
+  // Non-area actions (e.g. count/item-based actions like WBD1) don't compete
+  // for area, so they're excluded rather than mismeasured as hectares.
   const siblingActions = landAction.actions
     .filter((a) => a !== action)
+    .filter((a) => {
+      const unit = actions.find(
+        (config) => config.code === a.code
+      )?.applicationUnitOfMeasurement
+      return unit === undefined || unit === HECTARES
+    })
     .map((a) => ({ actionCode: a.code, areaSqm: haToSqm(a.quantity) }))
 
   const existingActions = [

--- a/src/features/application/service/action-validation.service.test.js
+++ b/src/features/application/service/action-validation.service.test.js
@@ -311,6 +311,79 @@ describe('Action Validation Service', () => {
       )
     })
 
+    test('should exclude a sibling action from existing area demand when its applicationUnitOfMeasurement is not hectares', async () => {
+      const countBasedSiblingAction = { code: 'WBD1', quantity: 5 }
+      const landActionWithSiblings = {
+        ...mockLandAction,
+        actions: [mockAction, countBasedSiblingAction]
+      }
+      const actionConfigWithWbd1 = [
+        ...mockActionConfig,
+        {
+          code: 'WBD1',
+          applicationUnitOfMeasurement: 'count'
+        }
+      ]
+      mockPlannedActionsTransformer.mockReturnValue([
+        { actionCode: 'LIG2', areaSqm: 1000000 }
+      ])
+
+      await validateLandAction(
+        mockAction,
+        actionConfigWithWbd1,
+        mockAgreements,
+        mockCompatibilityCheckFn,
+        landActionWithSiblings,
+        mockRequest
+      )
+
+      const expectedExistingActions = [{ actionCode: 'LIG2', areaSqm: 1000000 }]
+
+      expect(mockGetAvailableAreaDataRequirements).toHaveBeenCalledWith(
+        mockAction.code,
+        landActionWithSiblings.sheetId,
+        landActionWithSiblings.parcelId,
+        expectedExistingActions,
+        mockPostgresDb,
+        mockLogger
+      )
+      expect(mockFindMaximumAvailableArea).toHaveBeenCalledWith(
+        mockAction.code,
+        expectedExistingActions,
+        mockCompatibilityCheckFn,
+        mockAvailableAreaDataRequirements
+      )
+    })
+
+    test('should include a sibling action as area demand when its action config is not found', async () => {
+      const unknownSiblingAction = { code: 'UNKNOWN1', quantity: 5 }
+      const landActionWithSiblings = {
+        ...mockLandAction,
+        actions: [mockAction, unknownSiblingAction]
+      }
+      mockPlannedActionsTransformer.mockReturnValue([])
+
+      await validateLandAction(
+        mockAction,
+        mockActionConfig,
+        mockAgreements,
+        mockCompatibilityCheckFn,
+        landActionWithSiblings,
+        mockRequest
+      )
+
+      const expectedExistingActions = [
+        { actionCode: 'UNKNOWN1', areaSqm: 50000 }
+      ]
+
+      expect(mockFindMaximumAvailableArea).toHaveBeenCalledWith(
+        mockAction.code,
+        expectedExistingActions,
+        mockCompatibilityCheckFn,
+        mockAvailableAreaDataRequirements
+      )
+    })
+
     test('should throw InfeasibleAreaError when AAC returns feasible: false', async () => {
       mockFindMaximumAvailableArea.mockReturnValue({
         feasible: false,

--- a/src/features/rules-engine/rules/1.0.0/manual-check-required.js
+++ b/src/features/rules-engine/rules/1.0.0/manual-check-required.js
@@ -3,15 +3,14 @@
  * @import { ActionRule } from '~/src/features/actions/action.d.js'
  */
 
-// Generic, config-driven manual-check rule: unlike sssi-consent-required/
-// hefer-consent-required, this isn't an automated GIS-overlap eligibility check - it
-// always passes and always attaches a caveat, flagging that a human (RPA caseworker) must
-// review something eligibility rules can't determine automatically. Reusable by any action
-// via config alone: set rule.type = 'manual-check-required' and rule.name to the specific
-// caveat identity (e.g. 'pond-check-required' for WBD1) - no new land-grants-api code is
-// needed for a future action's manual check.
-
 /**
+ * Generic, config-driven manual-check rule: unlike sssi-consent-required/
+ * hefer-consent-required, this isn't an automated GIS-overlap eligibility check - it
+ * always passes and always attaches a caveat, flagging that a human (RPA caseworker) must
+ * review something eligibility rules can't determine automatically. Reusable by any action
+ * via config alone: set rule.type = 'manual-check-required' and rule.name to the specific
+ * caveat identity (e.g. 'pond-check-required' for WBD1) - no new land-grants-api code is
+ * needed for a future action's manual check.
  * @param {RuleEngineApplication} application - The application to execute the rule on
  * @param {ActionRule} rule - The rule to execute
  * @returns {RuleResultItem} - The result of the rule

--- a/src/features/rules-engine/rules/1.0.0/manual-check-required.js
+++ b/src/features/rules-engine/rules/1.0.0/manual-check-required.js
@@ -1,0 +1,49 @@
+/**
+ * @import { RuleEngineApplication, RuleResultItem } from '~/src/features/rules-engine/rules.d.js'
+ * @import { ActionRule } from '~/src/features/actions/action.d.js'
+ */
+
+// Generic, config-driven manual-check rule: unlike sssi-consent-required/
+// hefer-consent-required, this isn't an automated GIS-overlap eligibility check - it
+// always passes and always attaches a caveat, flagging that a human (RPA caseworker) must
+// review something eligibility rules can't determine automatically. Reusable by any action
+// via config alone: set rule.type = 'manual-check-required' and rule.name to the specific
+// caveat identity (e.g. 'pond-check-required' for WBD1) - no new land-grants-api code is
+// needed for a future action's manual check.
+
+/**
+ * @param {RuleEngineApplication} application - The application to execute the rule on
+ * @param {ActionRule} rule - The rule to execute
+ * @returns {RuleResultItem} - The result of the rule
+ */
+export const manualCheckRequired = {
+  execute: (application, rule) => {
+    const { caveatDescription } = rule.config
+    const { parcelId, sheetId, actionCode } = application
+    const name = rule.name
+
+    const caveat = {
+      code: name,
+      description: caveatDescription,
+      metadata: {
+        actionCode,
+        parcelId,
+        sheetId
+      }
+    }
+
+    return {
+      name,
+      passed: true,
+      description: rule.description,
+      reason: caveatDescription,
+      explanations: [
+        {
+          title: 'Manual check required',
+          lines: [caveatDescription]
+        }
+      ],
+      caveat
+    }
+  }
+}

--- a/src/features/rules-engine/rules/1.0.0/manual-check-required.test.js
+++ b/src/features/rules-engine/rules/1.0.0/manual-check-required.test.js
@@ -1,0 +1,81 @@
+import { manualCheckRequired } from './manual-check-required.js'
+
+describe('manualCheckRequired', () => {
+  const createApplication = (overrides = {}) => ({
+    parcelId: '9215',
+    sheetId: 'SD5649',
+    actionCode: 'WBD1',
+    ...overrides
+  })
+
+  const createRule = (
+    name = 'pond-check-required',
+    caveatDescription = 'A manual pond check is required'
+  ) => ({
+    name,
+    type: 'manual-check-required',
+    description: 'Manual check that the pond is not on SSSI land',
+    config: { caveatDescription }
+  })
+
+  test('always passes', () => {
+    const result = manualCheckRequired.execute(
+      createApplication(),
+      createRule()
+    )
+
+    expect(result.passed).toBe(true)
+  })
+
+  test('always attaches a caveat using the rule name as the caveat code', () => {
+    const result = manualCheckRequired.execute(
+      createApplication(),
+      createRule()
+    )
+
+    expect(result.caveat).toEqual({
+      code: 'pond-check-required',
+      description: 'A manual pond check is required',
+      metadata: {
+        actionCode: 'WBD1',
+        parcelId: '9215',
+        sheetId: 'SD5649'
+      }
+    })
+  })
+
+  test('is reusable for a different action via a different rule name/description', () => {
+    const application = createApplication({
+      actionCode: 'ABC1',
+      parcelId: '1111',
+      sheetId: 'AB1234'
+    })
+    const rule = createRule(
+      'abc1-check-required',
+      'A manual ABC1 check is required'
+    )
+
+    const result = manualCheckRequired.execute(application, rule)
+
+    expect(result.caveat).toEqual({
+      code: 'abc1-check-required',
+      description: 'A manual ABC1 check is required',
+      metadata: {
+        actionCode: 'ABC1',
+        parcelId: '1111',
+        sheetId: 'AB1234'
+      }
+    })
+  })
+
+  test('returns the rule description on the result', () => {
+    const result = manualCheckRequired.execute(
+      createApplication(),
+      createRule()
+    )
+
+    expect(result.description).toBe(
+      'Manual check that the pond is not on SSSI land'
+    )
+  })
+})

--- a/src/features/rules-engine/rules/index.js
+++ b/src/features/rules-engine/rules/index.js
@@ -3,6 +3,7 @@ import { appliedForTotalAvailableArea } from './1.0.0/applied-for-total-availabl
 import { appliedForTotalOrPartialAvailableArea } from './1.0.0/applied-for-total-or-partial-available-area.js'
 import { sssiConsentRequired } from './1.0.0/sssi-consent-required.js'
 import { heferConsentRequired } from './1.0.0/hefer-consent-required.js'
+import { manualCheckRequired } from './1.0.0/manual-check-required.js'
 import { woodlandMinimumEligibility } from './1.0.0/woodland-minimum-eligibility.js'
 import { woodlandTotalArea } from './1.0.0/woodland-total-area.js'
 import { parcelIntersectionDoesNotExceedMaximumForDataLayer } from './1.0.0/parcel-intersection-does-not-exceed-maximum-for-data-layer.js'
@@ -15,6 +16,7 @@ export const rules = {
     appliedForTotalOrPartialAvailableArea,
   'sssi-consent-required-1.0.0': sssiConsentRequired,
   'hefer-consent-required-1.0.0': heferConsentRequired,
+  'manual-check-required-1.0.0': manualCheckRequired,
   'parcel-has-minimum-eligibility-for-woodland-management-plan-1.0.0':
     woodlandMinimumEligibility,
   'total-area-not-exceed-land-parcels-woodland-management-plan-1.0.0':

--- a/src/features/rules-engine/rulesEngine.js
+++ b/src/features/rules-engine/rulesEngine.js
@@ -15,7 +15,11 @@
 export const executeRules = (rules, application, actionRules = []) => {
   const results = actionRules.map((rule) => {
     const version = rule.version ?? '1.0.0'
-    const ruleKey = `${rule.name}-${version}`
+    // `type` lets a config-defined rule name (e.g. a per-action caveat identity like
+    // 'pond-check-required') be dispatched to a shared, generic executor (e.g.
+    // 'manual-check-required') without needing its own registry entry. Falls back to
+    // `name` for every existing rule, which has no `type` - dispatch is unchanged for them.
+    const ruleKey = `${rule.type ?? rule.name}-${version}`
     return rules[ruleKey]
       ? { ...rules[ruleKey].execute(application, rule) }
       : { name: rule.name, passed: false, message: 'Rule not found' }

--- a/src/features/rules-engine/rulesEngine.test.js
+++ b/src/features/rules-engine/rulesEngine.test.js
@@ -220,6 +220,45 @@ describe('Rules Engine', function () {
     })
   })
 
+  test('should dispatch by rule.type when present, ignoring rule.name for lookup', function () {
+    const rulesWithGenericExecutor = {
+      'manual-check-required-1.0.0': {
+        execute: (application, rule) => ({
+          name: rule.name,
+          passed: true,
+          caveat: { code: rule.name }
+        })
+      }
+    }
+
+    const result = executeRules(rulesWithGenericExecutor, application, [
+      {
+        name: 'pond-check-required',
+        type: 'manual-check-required',
+        config: { caveatDescription: 'A manual pond check is required' }
+      }
+    ])
+
+    expect(result).toStrictEqual({
+      passed: true,
+      results: [
+        {
+          name: 'pond-check-required',
+          passed: true,
+          caveat: { code: 'pond-check-required' }
+        }
+      ]
+    })
+  })
+
+  test('should fall back to rule.name for dispatch when rule.type is absent', function () {
+    const result = executeRules(rules, application, [
+      mockActionConfig[0].rules[0]
+    ])
+
+    expect(result.passed).toBe(true)
+  })
+
   test('should pass application and rule to execute function', function () {
     const mockExecute = vi.fn(() => ({
       name: 'test-rule',

--- a/src/features/rules-engine/wbd1-rules.test.js
+++ b/src/features/rules-engine/wbd1-rules.test.js
@@ -1,0 +1,105 @@
+import { executeRules } from './rulesEngine.js'
+import { rules } from './rules/index.js'
+
+// Exercises WBD1's two configured rules together, using the exact rules[] array from
+// grants-config-land-grants/configurations/land-grants/actions/WBD1/wbd1-1.0.0.json,
+// against the real rule registry (not mocks) - hefer-consent-required is an existing,
+// generic, config-driven rule that needs no code change to work for WBD1; the new
+// manual-check-required rule (dispatched via pond-check-required's `type`) always
+// attaches its caveat.
+
+const WBD1_RULES = [
+  {
+    name: 'hefer-consent-required',
+    config: {
+      layerName: 'historic_features',
+      tolerancePercent: 0,
+      caveatDescription: 'A hefer is needed from Historic England'
+    },
+    description:
+      'Does the site require a Historic Environment Farm Environment Record?'
+  },
+  {
+    name: 'pond-check-required',
+    type: 'manual-check-required',
+    config: {
+      caveatDescription: 'A manual pond check is required'
+    },
+    description: 'Manual check that the pond is not on SSSI land'
+  }
+]
+
+const buildApplication = (intersectingAreaPercentage) => ({
+  parcelId: '9215',
+  sheetId: 'SD5649',
+  actionCode: 'WBD1',
+  landParcel: {
+    intersections: {
+      historic_features: {
+        intersectingAreaPercentage,
+        intersectionAreaHa: 0.05
+      }
+    }
+  }
+})
+
+describe('WBD1 rules (hefer-consent-required + pond-check-required)', () => {
+  test('always attaches the pond-check-required caveat, regardless of HEFER overlap', () => {
+    const result = executeRules(rules, buildApplication(0), WBD1_RULES)
+
+    const pondCheckResult = result.results.find(
+      (r) => r.name === 'pond-check-required'
+    )
+    expect(pondCheckResult.passed).toBe(true)
+    expect(pondCheckResult.caveat).toEqual({
+      code: 'pond-check-required',
+      description: 'A manual pond check is required',
+      metadata: {
+        actionCode: 'WBD1',
+        parcelId: '9215',
+        sheetId: 'SD5649'
+      }
+    })
+  })
+
+  test('hefer-consent-required attaches a caveat when overlap exceeds tolerance', () => {
+    const result = executeRules(rules, buildApplication(5), WBD1_RULES)
+
+    const heferResult = result.results.find(
+      (r) => r.name === 'hefer-consent-required'
+    )
+    expect(heferResult.passed).toBe(true)
+    expect(heferResult.caveat).toEqual({
+      code: 'hefer-consent-required',
+      description: 'A hefer is needed from Historic England',
+      metadata: {
+        actionCode: 'WBD1',
+        parcelId: '9215',
+        sheetId: 'SD5649',
+        percentageOverlap: 5,
+        overlapAreaHectares: 0.05
+      }
+    })
+  })
+
+  test('hefer-consent-required attaches no caveat when there is no overlap', () => {
+    const result = executeRules(rules, buildApplication(0), WBD1_RULES)
+
+    const heferResult = result.results.find(
+      (r) => r.name === 'hefer-consent-required'
+    )
+    expect(heferResult.passed).toBe(true)
+    expect(heferResult.caveat).toBeUndefined()
+  })
+
+  test('both rules pass overall, and both are represented in the results', () => {
+    const result = executeRules(rules, buildApplication(5), WBD1_RULES)
+
+    expect(result.passed).toBe(true)
+    expect(result.results).toHaveLength(2)
+    expect(result.results.map((r) => r.name)).toEqual([
+      'hefer-consent-required',
+      'pond-check-required'
+    ])
+  })
+})


### PR DESCRIPTION
Adds an optional `rule.type` field: rulesEngine.js now dispatches on `${rule.type ?? rule.name}-${version}`, falling back to `name` for every existing rule (all of which have no `type` - dispatch is unchanged for them).

A single generic executor is registered once as
'manual-check-required'; any action config can reuse it by setting `type: 'manual-check-required'` with a per-action `name` (the caveat identity) and `config.caveatDescription` - no further code change needed.