### PR TITLE
GSPS-555 Fix payment calculation for actions with mixed durations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4819,9 +4819,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4900,9 +4900,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8704,9 +8704,9 @@
       }
     },
     "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8923,9 +8923,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10352,9 +10352,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10564,9 +10564,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10642,9 +10642,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/features/payment-calculation/amountCalculation.js
+++ b/src/features/payment-calculation/amountCalculation.js
@@ -25,27 +25,34 @@ const findActionByCode = (code, actions = []) => {
 
 /**
  * Calculates annual and total payments in pence for all parcels of an application
- * @param {Array<PaymentParcelItem>} parcelItems
- * @param {Array<PaymentAgreementItem>} agreementItems
- * @param {number} durationYears
+ *
+ * The agreement total is calculated using the duration of each individual item,
+ * so actions with different durations contribute their own total to the agreement.
+ * @param {object} parcelItems
+ * @param {object} agreementItems
  * @returns {{annualTotalPence: number, agreementTotalPence: number}}
  */
 export const calculateAnnualAndAgreementTotals = (
   parcelItems,
-  agreementItems,
-  durationYears
+  agreementItems
 ) => {
   let annualTotalPence = 0
+  let agreementTotalPence = 0
   for (const [, parcelItem] of Object.entries(parcelItems)) {
-    annualTotalPence += parcelItem.annualPaymentPence ?? 0
+    const annualPaymentPence = parcelItem.annualPaymentPence ?? 0
+    annualTotalPence += annualPaymentPence
+    agreementTotalPence += annualPaymentPence * (parcelItem.durationYears ?? 0)
   }
   for (const [, agreementItem] of Object.entries(agreementItems)) {
-    annualTotalPence += agreementItem.annualPaymentPence ?? 0
+    const annualPaymentPence = agreementItem.annualPaymentPence ?? 0
+    annualTotalPence += annualPaymentPence
+    agreementTotalPence +=
+      annualPaymentPence * (agreementItem.durationYears ?? 0)
   }
 
   return {
     annualTotalPence: Math.floor(annualTotalPence),
-    agreementTotalPence: Math.floor(annualTotalPence * durationYears)
+    agreementTotalPence: Math.floor(agreementTotalPence)
   }
 }
 
@@ -77,6 +84,32 @@ export const reconcilePaymentAmounts = (
 }
 
 /**
+ * Calculates the number of pennies to shift to the first payment for an item so
+ * that the sum of its line items exactly matches its agreement total
+ * (annualPaymentPence * durationYears) over the payments it appears in.
+ * @param {PaymentParcelItem | PaymentAgreementItem} item
+ * @param {Array<ScheduledPayment>} payments
+ * @param {(lineItem: LineItem) => boolean} findLineItem
+ * @returns {{penniesToShift: number, flooredTotal: number}}
+ */
+const calculatePenniesToShift = (item, payments, findLineItem) => {
+  let flooredTotal = 0
+  for (const payment of payments) {
+    const lineItem = payment.lineItems.find(findLineItem)
+    if (lineItem) {
+      flooredTotal += Math.floor(lineItem.paymentPence)
+    }
+  }
+
+  const itemTotal = (item.annualPaymentPence ?? 0) * (item.durationYears ?? 0)
+
+  return {
+    penniesToShift: itemTotal - flooredTotal,
+    flooredTotal
+  }
+}
+
+/**
  * Shifts payment pennies from all payments to the first scheduled payment
  * @param {Array<ScheduledPayment>} payments
  * @param {Array<PaymentParcelItem>} parcelItems
@@ -100,11 +133,13 @@ const shiftTotalPenniesToFirstScheduledPayment = (
   // Note: this calculates the total number of pennies to shift to the first payment
   // Note: use the parcelItems annualPaymentPence, as this contains the correct annualPaymentPence
   for (const [parcelItemId, parcelItem] of Object.entries(parcelItems)) {
-    const penniesToShift =
-      (parcelItem.annualPaymentPence * parcelItem.durationYears) %
-      payments.length
+    const { penniesToShift, flooredTotal } = calculatePenniesToShift(
+      parcelItem,
+      adjustedPayments,
+      (lineItem) => lineItem.parcelItemId === Number(parcelItemId)
+    )
     explanations.push(
-      `- Shifting ${penniesToShift} pennies to first payment for parcel ${parcelItem.code}: ${parcelItem.annualPaymentPence} * ${parcelItem.durationYears} mod ${payments.length} = ${penniesToShift} pence`
+      `- Shifting ${penniesToShift} pennies to first payment for parcel ${parcelItem.code}: (${parcelItem.annualPaymentPence} * ${parcelItem.durationYears}) - ${flooredTotal} = ${penniesToShift} pence`
     )
 
     // add pennies for each individual line item of the first payment
@@ -122,11 +157,13 @@ const shiftTotalPenniesToFirstScheduledPayment = (
   for (const [agreementItemId, agreementItem] of Object.entries(
     agreementItems
   )) {
-    const penniesToShift =
-      (agreementItem.annualPaymentPence * agreementItem.durationYears) %
-      payments.length
+    const { penniesToShift, flooredTotal } = calculatePenniesToShift(
+      agreementItem,
+      adjustedPayments,
+      (lineItem) => lineItem.agreementLevelItemId === Number(agreementItemId)
+    )
     explanations.push(
-      `- Shifting ${penniesToShift} pennies to first payment for agreement ${agreementItem.code}: ${agreementItem.annualPaymentPence} * ${agreementItem.durationYears} mod ${payments.length} = ${penniesToShift} pence`
+      `- Shifting ${penniesToShift} pennies to first payment for agreement ${agreementItem.code}: (${agreementItem.annualPaymentPence} * ${agreementItem.durationYears}) - ${flooredTotal} = ${penniesToShift} pence`
     )
 
     // add pennies for each individual line item of the first payment
@@ -183,6 +220,27 @@ const calculatePaymentsPerYear = (schedule) => {
 }
 
 /**
+ * Determines whether an item is paid on a given payment. An item is paid
+ * quarterly for the full length of its own duration, starting from the first
+ * scheduled payment, so shorter duration actions stop being paid before longer
+ * duration actions.
+ * @param {number | undefined} durationYears
+ * @param {number} paymentsPerYear
+ * @param {number} paymentIndex
+ * @returns {boolean}
+ */
+const isItemActiveAtPayment = (
+  durationYears,
+  paymentsPerYear,
+  paymentIndex
+) => {
+  if (durationYears == null) {
+    return true
+  }
+  return paymentIndex < durationYears * paymentsPerYear
+}
+
+/**
  * Calculates scheduled payments information for all parcels items and agreement level items
  * @param {Array<PaymentParcelItem>} parcelItems
  * @param {Array<PaymentAgreementItem>} agreementLevelItems
@@ -196,11 +254,20 @@ export const calculateScheduledPayments = (
 ) => {
   const paymentsPerYear = calculatePaymentsPerYear(schedule)
 
-  return schedule.map((paymentDate) => {
+  return schedule.map((paymentDate, paymentIndex) => {
     const lineItems = []
     let totalPaymentPence = 0
 
     for (const [id, parcelItem] of Object.entries(parcelItems)) {
+      if (
+        !isItemActiveAtPayment(
+          parcelItem.durationYears,
+          paymentsPerYear,
+          paymentIndex
+        )
+      ) {
+        continue
+      }
       const paymentPence = parcelItem.annualPaymentPence / paymentsPerYear
       lineItems.push({
         parcelItemId: Number(id),
@@ -211,6 +278,15 @@ export const calculateScheduledPayments = (
     }
 
     for (const [id, agreementItem] of Object.entries(agreementLevelItems)) {
+      if (
+        !isItemActiveAtPayment(
+          agreementItem.durationYears,
+          paymentsPerYear,
+          paymentIndex
+        )
+      ) {
+        continue
+      }
       const paymentPence = agreementItem.annualPaymentPence / paymentsPerYear
       lineItems.push({
         agreementLevelItemId: Number(id),
@@ -387,7 +463,7 @@ const addAgreementItem = (
 }
 
 /**
- * @import { PaymentParcel, ScheduledPayment, PaymentParcelAction, PaymentParcelItem, PaymentAgreementItem } from './payment-calculation.d.js'
+ * @import { PaymentParcel, ScheduledPayment, PaymentParcelAction, PaymentParcelItem, PaymentAgreementItem, LineItem } from './payment-calculation.d.js'
  * @import { Action } from '../actions/action.d.js'
  * @import { ExplanationSection } from '~/src/features/available-area/explanations.d.js'
  */

--- a/src/features/payment-calculation/amountCalculation.js
+++ b/src/features/payment-calculation/amountCalculation.js
@@ -110,6 +110,27 @@ const calculatePenniesToShift = (item, payments, findLineItem) => {
 }
 
 /**
+ * Formats the distinct payment amounts of a list of payments with their
+ * occurrence counts, e.g. "359827 pence (x3), 220480 pence (x8)". When all
+ * payments are the same this degrades to a single entry, e.g. "9532 pence (x11)".
+ * @param {Array<ScheduledPayment>} payments
+ * @returns {string}
+ */
+export const formatDistinctPaymentBreakdown = (payments) => {
+  const breakdown = new Map()
+  for (const payment of payments) {
+    breakdown.set(
+      payment.totalPaymentPence,
+      (breakdown.get(payment.totalPaymentPence) ?? 0) + 1
+    )
+  }
+
+  return Array.from(breakdown.entries())
+    .map(([amount, count]) => `${amount} pence (x${count})`)
+    .join(', ')
+}
+
+/**
  * Shifts payment pennies from all payments to the first scheduled payment
  * @param {Array<ScheduledPayment>} payments
  * @param {Array<PaymentParcelItem>} parcelItems
@@ -185,7 +206,9 @@ const shiftTotalPenniesToFirstScheduledPayment = (
   explanations.push(
     `- TOTAL: ${firstAdjustedPayment.totalPaymentPence} pence/year`,
     `- FIRST PAYMENT (QUARTER) : ${adjustedPayments[1]?.totalPaymentPence} + ${decimalsForAllPayments} = ${firstAdjustedPayment.totalPaymentPence} pence`,
-    `- REST OF PAYMENTS (QUARTER): ${adjustedPayments[1]?.totalPaymentPence} pence`
+    `- QUARTERLY PAYMENTS (REST): ${formatDistinctPaymentBreakdown(
+      adjustedPayments.slice(1)
+    )}`
   )
 
   return { adjustedPayments, explanations }

--- a/src/features/payment-calculation/amountCalculation.test.js
+++ b/src/features/payment-calculation/amountCalculation.test.js
@@ -224,6 +224,34 @@ describe('calculateAnnualAndAgreementTotals', () => {
     expect(agreementTotalPence).toBe(0)
     expect(annualTotalPence).toBe(0)
   })
+
+  it('should use each items own duration when calculating the agreement total', () => {
+    const parcelItems = {
+      1: {
+        code: 'CLIG3',
+        annualPaymentPence: 109390,
+        durationYears: 1
+      },
+      2: {
+        code: 'SCR2',
+        annualPaymentPence: 350000,
+        durationYears: 3
+      }
+    }
+    const agreementItems = {
+      1: {
+        code: 'CSAM3',
+        annualPaymentPence: 9700,
+        durationYears: 1
+      }
+    }
+
+    const { agreementTotalPence, annualTotalPence } =
+      calculateAnnualAndAgreementTotals(parcelItems, agreementItems)
+
+    expect(annualTotalPence).toBe(469090)
+    expect(agreementTotalPence).toBe(109390 * 1 + 9700 * 1 + 350000 * 3)
+  })
 })
 
 describe('createPaymentItems', () => {
@@ -636,12 +664,12 @@ describe('reconcilePaymentAmounts', () => {
       1: {
         code: 'CMOR1',
         annualPaymentPence: 360,
-        durationYears: 3
+        durationYears: 1
       },
       2: {
         code: 'CSAM1',
         annualPaymentPence: 870,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -683,8 +711,8 @@ describe('reconcilePaymentAmounts', () => {
     const result = reconcilePaymentAmounts(parcelItems, {}, payments)
 
     // First payment should have pennies shifted to line items
-    // parcelItem 1: (360 * 3) % 4 = 0 pennies
-    // parcelItem 2: (870 * 3) % 4 = 2 pennies
+    // parcelItem 1: (360 * 1) - (4 * 90) = 0 pennies
+    // parcelItem 2: (870 * 1) - (4 * 217) = 2 pennies
     expect(result.payments[0].lineItems).toEqual([
       { parcelItemId: 1, paymentPence: 90 },
       { parcelItemId: 2, paymentPence: 219 } // 217 + 2
@@ -702,12 +730,12 @@ describe('reconcilePaymentAmounts', () => {
       1: {
         code: 'CMOR1',
         annualPaymentPence: 27200,
-        durationYears: 3
+        durationYears: 1
       },
       2: {
         code: 'CSAM1',
         annualPaymentPence: 9700,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -748,8 +776,8 @@ describe('reconcilePaymentAmounts', () => {
 
     const result = reconcilePaymentAmounts({}, agreementItems, payments)
 
-    // agreementItem 1: (27200 * 3) % 4 = 0 pennies
-    // agreementItem 2: (9700 * 3) % 4 = 0 pennies
+    // agreementItem 1: (27200 * 1) - (4 * 6800) = 0 pennies
+    // agreementItem 2: (9700 * 1) - (4 * 2425) = 0 pennies
     expect(result.payments[0].lineItems).toEqual([
       { agreementLevelItemId: 1, paymentPence: 6800 },
       { agreementLevelItemId: 2, paymentPence: 2425 }
@@ -761,7 +789,7 @@ describe('reconcilePaymentAmounts', () => {
       1: {
         code: 'TEST1',
         annualPaymentPence: 333,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -769,7 +797,7 @@ describe('reconcilePaymentAmounts', () => {
       1: {
         code: 'TEST1',
         annualPaymentPence: 555,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -814,12 +842,12 @@ describe('reconcilePaymentAmounts', () => {
       payments
     )
 
-    // parcelItem 1: (333 * 3) % 4 = 999 % 4 = 3 pennies
-    // agreementItem 1: (555 * 3) % 4 = 1665 % 4 = 1 penny
+    // parcelItem 1: (333 * 1) - (4 * 83) = 1 penny
+    // agreementItem 1: (555 * 1) - (4 * 138) = 3 pennies
     // Total shifted: 4 pennies
     expect(result.payments[0].lineItems).toEqual([
-      { parcelItemId: 1, paymentPence: 86 }, // floor(83.25) + 3 = 83 + 3
-      { agreementLevelItemId: 1, paymentPence: 139 } // floor(138.75) + 1 = 138 + 1
+      { parcelItemId: 1, paymentPence: 84 }, // floor(83.25) + 1 = 83 + 1
+      { agreementLevelItemId: 1, paymentPence: 141 } // floor(138.75) + 3 = 138 + 3
     ])
 
     expect(result.payments[0].totalPaymentPence).toBe(226) // 222 + 4
@@ -862,17 +890,17 @@ describe('reconcilePaymentAmounts', () => {
       1: {
         code: 'ITEM1',
         annualPaymentPence: 111,
-        durationYears: 3
+        durationYears: 1
       },
       2: {
         code: 'ITEM2',
         annualPaymentPence: 222,
-        durationYears: 3
+        durationYears: 1
       },
       3: {
         code: 'ITEM3',
         annualPaymentPence: 333,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -919,9 +947,9 @@ describe('reconcilePaymentAmounts', () => {
 
     // Total: 6 pennies shifted to first payment
     expect(result.payments[0].lineItems).toEqual([
-      { parcelItemId: 1, paymentPence: 28 }, // floor(27.75) + 1 = 27 + 1
+      { parcelItemId: 1, paymentPence: 30 }, // floor(27.75) + 3 = 27 + 3
       { parcelItemId: 2, paymentPence: 57 }, // floor(55.5) + 2 = 55 + 2
-      { parcelItemId: 3, paymentPence: 86 } // floor(83.25) + 3 = 83 + 3
+      { parcelItemId: 3, paymentPence: 84 } // floor(83.25) + 1 = 83 + 1
     ])
     expect(result.payments[0].totalPaymentPence).toBe(173) // Math.round(166.5 + 6) = Math.round(172.5)
 
@@ -947,17 +975,17 @@ describe('reconcilePaymentAmounts', () => {
     expect(result.agreementLevelItems).toBe(agreementItems)
   })
 
-  it('should handle when parcel line item is not found in first payment', () => {
+  it('should handle when parcel line item is not found in any payment', () => {
     const parcelItems = {
       1: {
         code: 'CMOR1',
         annualPaymentPence: 360,
-        durationYears: 3
+        durationYears: 1
       },
       999: {
         code: 'MISSING',
         annualPaymentPence: 111,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -986,26 +1014,26 @@ describe('reconcilePaymentAmounts', () => {
 
     const result = reconcilePaymentAmounts(parcelItems, {}, payments)
 
-    // Line item for parcelItemId 999 doesn't exist in payments
-    // (360 * 3) % 4 = 0 pennies for item 1
-    // (111 * 3) % 4 = 1 penny for item 999 (but line item not found, so added to total only)
+    // Line item for parcelItemId 999 doesn't exist in any payment
+    // item 1: (360 * 1) - (4 * 90) = 0 pennies
+    // item 999: (111 * 1) - 0 = 111 pennies (line item not found, so added to total only)
     expect(result.payments[0].lineItems).toEqual([
       { parcelItemId: 1, paymentPence: 90 }
     ])
-    expect(result.payments[0].totalPaymentPence).toBe(91) // 90 + 1 penny from missing item
+    expect(result.payments[0].totalPaymentPence).toBe(201) // 90 + 111 pennies from missing item
   })
 
-  it('should handle when agreement line item is not found in first payment', () => {
+  it('should handle when agreement line item is not found in any payment', () => {
     const agreementItems = {
       1: {
         code: 'CMOR1',
         annualPaymentPence: 27200,
-        durationYears: 3
+        durationYears: 1
       },
       999: {
         code: 'MISSING_AGREEMENT',
         annualPaymentPence: 555,
-        durationYears: 3
+        durationYears: 1
       }
     }
 
@@ -1034,13 +1062,13 @@ describe('reconcilePaymentAmounts', () => {
 
     const result = reconcilePaymentAmounts({}, agreementItems, payments)
 
-    // Line item for agreementLevelItemId 999 doesn't exist in payments
-    // (27200 * 3) % 4 = 0 pennies for item 1
-    // (555 * 3) % 4 = 1 penny for item 999 (but line item not found, so added to total only)
+    // Line item for agreementLevelItemId 999 doesn't exist in any payment
+    // item 1: (27200 * 1) - (4 * 6800) = 0 pennies
+    // item 999: (555 * 1) - 0 = 555 pennies (line item not found, so added to total only)
     expect(result.payments[0].lineItems).toEqual([
       { agreementLevelItemId: 1, paymentPence: 6800 }
     ])
-    expect(result.payments[0].totalPaymentPence).toBe(6801) // 6800 + 1 penny from missing item
+    expect(result.payments[0].totalPaymentPence).toBe(7355) // 6800 + 555 pennies from missing item
   })
 })
 
@@ -1240,5 +1268,196 @@ describe('calculateScheduledPayments', () => {
         lineItems
       }))
     )
+  })
+
+  it('should only include items in payments that fall within their duration', () => {
+    const parcelItems = {
+      1: {
+        code: 'CLIG3',
+        annualPaymentPence: 109390,
+        durationYears: 1
+      },
+      2: {
+        code: 'SCR2',
+        annualPaymentPence: 350000,
+        durationYears: 3
+      }
+    }
+
+    const schedule = [
+      '2026-06-15',
+      '2026-09-15',
+      '2026-12-15',
+      '2027-03-15',
+      '2027-06-15',
+      '2027-09-15',
+      '2027-12-15',
+      '2028-03-15',
+      '2028-06-15',
+      '2028-09-15',
+      '2028-12-15',
+      '2029-03-15'
+    ]
+
+    const result = calculateScheduledPayments(parcelItems, {}, schedule)
+
+    // CLIG3 (1 year) is only paid on the first 4 payments
+    expect(result[0].lineItems).toEqual([
+      { parcelItemId: 1, paymentPence: 27347.5 },
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+    expect(result[0].totalPaymentPence).toBe(114847) // floor(27347.5) + floor(87500)
+
+    // SCR2 (3 years) continues to be paid for the rest of the schedule
+    expect(result[4].lineItems).toEqual([
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+    expect(result[4].totalPaymentPence).toBe(87500)
+
+    expect(result[11].lineItems).toEqual([
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+    expect(result[11].totalPaymentPence).toBe(87500)
+
+    // the 1-year item is only present in the first 4 payments
+    const paymentsWithClig3 = result.filter((payment) =>
+      payment.lineItems.some((lineItem) => lineItem.parcelItemId === 1)
+    )
+    expect(paymentsWithClig3).toHaveLength(4)
+  })
+})
+
+describe('reconcilePaymentAmounts - mixed durations', () => {
+  it('should shift pennies per item over its own payment window', () => {
+    const parcelItems = {
+      1: {
+        code: 'CLIG3',
+        annualPaymentPence: 109390,
+        durationYears: 1
+      },
+      2: {
+        code: 'SCR2',
+        annualPaymentPence: 350000,
+        durationYears: 3
+      }
+    }
+
+    const payments = [
+      {
+        lineItems: [
+          { parcelItemId: 1, paymentPence: 27347.5 },
+          { parcelItemId: 2, paymentPence: 87500 }
+        ],
+        paymentDate: '2026-06-15',
+        totalPaymentPence: 114847
+      },
+      {
+        lineItems: [
+          { parcelItemId: 1, paymentPence: 27347.5 },
+          { parcelItemId: 2, paymentPence: 87500 }
+        ],
+        paymentDate: '2026-09-15',
+        totalPaymentPence: 114847
+      },
+      {
+        lineItems: [
+          { parcelItemId: 1, paymentPence: 27347.5 },
+          { parcelItemId: 2, paymentPence: 87500 }
+        ],
+        paymentDate: '2026-12-15',
+        totalPaymentPence: 114847
+      },
+      {
+        lineItems: [
+          { parcelItemId: 1, paymentPence: 27347.5 },
+          { parcelItemId: 2, paymentPence: 87500 }
+        ],
+        paymentDate: '2027-03-15',
+        totalPaymentPence: 114847
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2027-06-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2027-09-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2027-12-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2028-03-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2028-06-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2028-09-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2028-12-15',
+        totalPaymentPence: 87500
+      },
+      {
+        lineItems: [{ parcelItemId: 2, paymentPence: 87500 }],
+        paymentDate: '2029-03-15',
+        totalPaymentPence: 87500
+      }
+    ]
+
+    const result = reconcilePaymentAmounts(parcelItems, {}, payments)
+
+    // CLIG3 (1 year): (109390 * 1) - (4 * 27347) = 2 pennies
+    // SCR2 (3 years): (350000 * 3) - (12 * 87500) = 0 pennies
+    expect(result.payments[0].lineItems).toEqual([
+      { parcelItemId: 1, paymentPence: 27349 }, // floor(27347.5) + 2
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+    expect(result.payments[0].totalPaymentPence).toBe(114849) // 114847 + 2
+
+    expect(result.payments[1].lineItems).toEqual([
+      { parcelItemId: 1, paymentPence: 27347 },
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+    expect(result.payments[4].lineItems).toEqual([
+      { parcelItemId: 2, paymentPence: 87500 }
+    ])
+
+    // Each item's total payments match its own agreement total (annual * duration)
+    const clig3Total = result.payments.reduce(
+      (acc, payment) =>
+        acc +
+        (payment.lineItems.find((item) => item.parcelItemId === 1)
+          ?.paymentPence ?? 0),
+      0
+    )
+    const scr2Total = result.payments.reduce(
+      (acc, payment) =>
+        acc +
+        (payment.lineItems.find((item) => item.parcelItemId === 2)
+          ?.paymentPence ?? 0),
+      0
+    )
+    expect(clig3Total).toBe(109390)
+    expect(scr2Total).toBe(1050000)
+
+    // The sum of all scheduled payments equals the agreement total
+    const sumOfPayments = result.payments.reduce(
+      (acc, payment) => acc + payment.totalPaymentPence,
+      0
+    )
+    expect(sumOfPayments).toBe(clig3Total + scr2Total)
   })
 })

--- a/src/features/payment-calculation/amountCalculation.test.js
+++ b/src/features/payment-calculation/amountCalculation.test.js
@@ -857,6 +857,11 @@ describe('reconcilePaymentAmounts', () => {
       { parcelItemId: 1, paymentPence: 83 },
       { agreementLevelItemId: 1, paymentPence: 138 }
     ])
+
+    // With equal durations the rest-of-payments explanation collapses to one amount
+    expect(result.explanations.content).toContain(
+      '- QUARTERLY PAYMENTS (REST): 222 pence (x3)'
+    )
   })
 
   it('should correctly shift pennies when there is only one payment', () => {
@@ -1434,6 +1439,12 @@ describe('reconcilePaymentAmounts - mixed durations', () => {
     expect(result.payments[4].lineItems).toEqual([
       { parcelItemId: 2, paymentPence: 87500 }
     ])
+
+    // The rest-of-payments explanation shows the distinct amounts per period
+    // (3 payments of 114847 while the 1-year action is active, then 8 of 87500)
+    expect(result.explanations.content).toContain(
+      '- QUARTERLY PAYMENTS (REST): 114847 pence (x3), 87500 pence (x8)'
+    )
 
     // Each item's total payments match its own agreement total (annual * duration)
     const clig3Total = result.payments.reduce(

--- a/src/features/payment-calculation/paymentCalculation.js
+++ b/src/features/payment-calculation/paymentCalculation.js
@@ -2,6 +2,7 @@ import {
   calculateAnnualAndAgreementTotals,
   calculateScheduledPayments,
   createPaymentItems,
+  formatDistinctPaymentBreakdown,
   reconcilePaymentAmounts
 } from './amountCalculation.js'
 import { generatePaymentSchedule } from './generateSchedule.js'
@@ -67,7 +68,9 @@ export const getPaymentCalculationForParcels = (
       `Total agreement payment: ${agreementTotalPence} pence/year`,
       `Total annual payment: ${annualTotalPence} pence/year`,
       `First quarter payment: ${revisedPayments[0].totalPaymentPence} pence`,
-      `Rest quarters payment: ${revisedPayments[1].totalPaymentPence} pence`
+      `Quarterly payments: ${formatDistinctPaymentBreakdown(
+        revisedPayments.slice(1)
+      )}`
     ])
   ]
 

--- a/src/features/payment-calculation/paymentCalculation.js
+++ b/src/features/payment-calculation/paymentCalculation.js
@@ -32,11 +32,7 @@ export const getPaymentCalculationForParcels = (
 
   // calculate total amounts
   const { annualTotalPence, agreementTotalPence } =
-    calculateAnnualAndAgreementTotals(
-      parcelItems,
-      agreementItems,
-      durationYears
-    )
+    calculateAnnualAndAgreementTotals(parcelItems, agreementItems)
 
   // generate date schedule
   const { agreementStartDate, agreementEndDate, schedule } =

--- a/src/features/payment-calculation/paymentCalculation.test.js
+++ b/src/features/payment-calculation/paymentCalculation.test.js
@@ -478,6 +478,14 @@ describe('getPaymentCalculationForParcels', () => {
       0
     )
     expect(sumOfPayments).toBe(response.agreementTotalPence)
+
+    // The summary explanation reflects the distinct payment amounts per period
+    const summarySection = response.explanations.find(
+      (section) => section.title === 'Summary'
+    )
+    expect(summarySection.content).toContain(
+      'Quarterly payments: 359827 pence (x3), 220480 pence (x8)'
+    )
     vi.useRealTimers()
   })
 })

--- a/src/features/payment-calculation/paymentCalculation.test.js
+++ b/src/features/payment-calculation/paymentCalculation.test.js
@@ -38,11 +38,48 @@ const mockEnabledActions = [
   }
 ]
 
+const firstPaymentLineItems = [
+  {
+    parcelItemId: 1,
+    paymentPence: 90
+  },
+  {
+    parcelItemId: 2,
+    paymentPence: 223
+  },
+  {
+    agreementLevelItemId: 1,
+    paymentPence: 6800
+  },
+  {
+    agreementLevelItemId: 2,
+    paymentPence: 2425
+  }
+]
+const otherPaymentLineItems = [
+  {
+    parcelItemId: 1,
+    paymentPence: 90
+  },
+  {
+    parcelItemId: 2,
+    paymentPence: 217
+  },
+  {
+    agreementLevelItemId: 1,
+    paymentPence: 6800
+  },
+  {
+    agreementLevelItemId: 2,
+    paymentPence: 2425
+  }
+]
+
 describe('getPaymentCalculationForParcels', () => {
   it('should return a valid payload for valid parcel data', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2025, 6, 2))
-    const durationYears = 1
+    const durationYears = 3
 
     const parcels = [
       {
@@ -67,47 +104,11 @@ describe('getPaymentCalculationForParcels', () => {
       }
     ]
 
-    const firstPaymentLineItems = [
-      {
-        parcelItemId: 1,
-        paymentPence: 90
-      },
-      {
-        parcelItemId: 2,
-        paymentPence: 219
-      },
-      {
-        agreementLevelItemId: 1,
-        paymentPence: 6800
-      },
-      {
-        agreementLevelItemId: 2,
-        paymentPence: 2425
-      }
-    ]
-    const otherPaymentLineItems = [
-      {
-        parcelItemId: 1,
-        paymentPence: 90
-      },
-      {
-        parcelItemId: 2,
-        paymentPence: 217
-      },
-      {
-        agreementLevelItemId: 1,
-        paymentPence: 6800
-      },
-      {
-        agreementLevelItemId: 2,
-        paymentPence: 2425
-      }
-    ]
     const expectedResponse = {
       agreementStartDate: '2025-08-01',
-      agreementEndDate: '2026-07-31',
+      agreementEndDate: '2028-07-31',
       frequency: 'Quarterly',
-      agreementTotalPence: 38130,
+      agreementTotalPence: 114390,
       annualTotalPence: 38130,
       parcelItems: {
         1: {
@@ -157,7 +158,7 @@ describe('getPaymentCalculationForParcels', () => {
         {
           lineItems: firstPaymentLineItems,
           paymentDate: '2025-11-15',
-          totalPaymentPence: 9534
+          totalPaymentPence: 9538
         },
         {
           lineItems: otherPaymentLineItems,
@@ -172,6 +173,46 @@ describe('getPaymentCalculationForParcels', () => {
         {
           lineItems: otherPaymentLineItems,
           paymentDate: '2026-08-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2026-11-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-02-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-05-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-08-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-11-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-02-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-05-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-08-15',
           totalPaymentPence: 9532
         }
       ],
@@ -191,7 +232,7 @@ describe('getPaymentCalculationForParcels', () => {
   it('should return a response based on startDate if provided', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2025, 6, 2))
-    const durationYears = 1
+    const durationYears = 3
 
     const parcels = [
       {
@@ -216,47 +257,11 @@ describe('getPaymentCalculationForParcels', () => {
       }
     ]
 
-    const firstPaymentLineItems = [
-      {
-        parcelItemId: 1,
-        paymentPence: 90
-      },
-      {
-        parcelItemId: 2,
-        paymentPence: 219
-      },
-      {
-        agreementLevelItemId: 1,
-        paymentPence: 6800
-      },
-      {
-        agreementLevelItemId: 2,
-        paymentPence: 2425
-      }
-    ]
-    const otherPaymentLineItems = [
-      {
-        parcelItemId: 1,
-        paymentPence: 90
-      },
-      {
-        parcelItemId: 2,
-        paymentPence: 217
-      },
-      {
-        agreementLevelItemId: 1,
-        paymentPence: 6800
-      },
-      {
-        agreementLevelItemId: 2,
-        paymentPence: 2425
-      }
-    ]
     const expectedResponse = {
       agreementStartDate: '2026-02-01',
-      agreementEndDate: '2027-01-31',
+      agreementEndDate: '2029-01-31',
       frequency: 'Quarterly',
-      agreementTotalPence: 38130,
+      agreementTotalPence: 114390,
       annualTotalPence: 38130,
       parcelItems: {
         1: {
@@ -306,7 +311,7 @@ describe('getPaymentCalculationForParcels', () => {
         {
           lineItems: firstPaymentLineItems,
           paymentDate: '2026-05-15',
-          totalPaymentPence: 9534
+          totalPaymentPence: 9538
         },
         {
           lineItems: otherPaymentLineItems,
@@ -322,6 +327,46 @@ describe('getPaymentCalculationForParcels', () => {
           lineItems: otherPaymentLineItems,
           paymentDate: '2027-02-15',
           totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-05-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-08-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2027-11-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-02-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-05-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-08-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2028-11-15',
+          totalPaymentPence: 9532
+        },
+        {
+          lineItems: otherPaymentLineItems,
+          paymentDate: '2029-02-15',
+          totalPaymentPence: 9532
         }
       ],
       explanations: expect.any(Array)
@@ -335,6 +380,104 @@ describe('getPaymentCalculationForParcels', () => {
     )
 
     expect(response).toEqual(expectedResponse)
+    vi.useRealTimers()
+  })
+
+  it('should calculate payments using each action duration when durations differ', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 1, 1))
+
+    const mixedDurationActions = [
+      {
+        code: 'CLIG3',
+        description: 'Manage grassland with very low nutrient inputs',
+        version: 1,
+        applicationUnitOfMeasurement: 'ha',
+        durationYears: 1,
+        payment: {
+          ratePerUnitGbp: 151
+        }
+      },
+      {
+        code: 'CSAM3',
+        description: 'Herbal leys',
+        version: 1,
+        applicationUnitOfMeasurement: 'ha',
+        durationYears: 1,
+        payment: {
+          ratePerUnitGbp: 224
+        }
+      },
+      {
+        code: 'SCR2',
+        description: 'Manage scrub and open habitat mosaics',
+        version: 1,
+        applicationUnitOfMeasurement: 'ha',
+        durationYears: 3,
+        payment: {
+          ratePerUnitGbp: 350
+        }
+      }
+    ]
+
+    const parcels = [
+      {
+        sheetId: 'NT8907',
+        parcelId: '2407',
+        actions: [
+          { code: 'CLIG3', quantity: 7.2444 },
+          { code: 'SCR2', quantity: 10 }
+        ]
+      },
+      {
+        sheetId: 'SK7949',
+        parcelId: '9475',
+        actions: [
+          { code: 'CSAM3', quantity: 20 },
+          { code: 'SCR2', quantity: 15.1978 }
+        ]
+      }
+    ]
+
+    const response = getPaymentCalculationForParcels(
+      parcels,
+      mixedDurationActions,
+      3,
+      '2026-02-01'
+    )
+
+    expect(response.agreementTotalPence).toBe(3203159)
+    expect(response.annualTotalPence).toBe(1439313)
+
+    expect(response.payments).toHaveLength(12)
+
+    // The 1-year actions (CLIG3, CSAM3) are only paid during the first 4
+    // payments, while the 3-year action (SCR2) is paid for all 12 payments.
+    const firstYearPayments = response.payments.slice(0, 4)
+    const remainingPayments = response.payments.slice(4)
+
+    for (const payment of firstYearPayments) {
+      const codes = payment.lineItems.map(
+        (item) => response.parcelItems[item.parcelItemId]?.code
+      )
+      expect(codes).toEqual(
+        expect.arrayContaining(['CLIG3', 'CSAM3', 'SCR2', 'SCR2'])
+      )
+    }
+
+    for (const payment of remainingPayments) {
+      const codes = payment.lineItems.map(
+        (item) => response.parcelItems[item.parcelItemId]?.code
+      )
+      expect(codes).toEqual(['SCR2', 'SCR2'])
+    }
+
+    // The sum of all scheduled payments must exactly equal the agreement total
+    const sumOfPayments = response.payments.reduce(
+      (acc, payment) => acc + payment.totalPaymentPence,
+      0
+    )
+    expect(sumOfPayments).toBe(response.agreementTotalPence)
     vi.useRealTimers()
   })
 })


### PR DESCRIPTION
Previously the agreement total, payment schedule, and penny reconciliation all assumed every action had the same duration as the agreement. This produced an incorrect agreementTotalPence and scheduled payments that drifted from the total by a few pence when actions had differing durations (e.g. 1-year CLIG3/CSAM3 alongside a 3-year SCR2).

- calculateAnnualAndAgreementTotals now uses each item's own durationYears when computing agreementTotalPence
- calculateScheduledPayments stops paying an item once its own duration has elapsed
- Penny reconciliation now compares each item's total against the payments it actually appears in, so the sum of scheduled payments always equals agreementTotalPence
- Added unit tests and DB scenario verification for mixed-duration agreements